### PR TITLE
Support other digest types

### DIFF
--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -105,14 +105,32 @@ public abstract class BodyRequestBuilder extends
     }
 
     /**
+     * Provide a checksum for the body of this request
+     * 
+     * @param digest checksum to provide as the digest for the request body
+     * @param alg abbreviated algorithm identifier for the type of checksum being
+     *      added (for example, sha1, md5, etc)
+     * @return this builder
+     */
+    protected BodyRequestBuilder digest(final String digest, final String alg) {
+        if (digest != null) {
+            if (digestJoiner == null) {
+                digestJoiner = new StringJoiner(", ");
+            }
+            digestJoiner.add(alg + "=" + digest);
+            request.setHeader(DIGEST, digestJoiner.toString());
+        }
+        return this;
+    }
+
+    /**
      * Provide a SHA-1 checksum for the body of this request
      * 
      * @param digest sha-1 checksum to provide as the digest for the request body
      * @return this builder
      */
     protected BodyRequestBuilder digestSha1(final String digest) {
-        addDigest(digest, "sha1");
-        return this;
+        return digest(digest, "sha1");
     }
 
     /**
@@ -122,8 +140,7 @@ public abstract class BodyRequestBuilder extends
      * @return this builder
      */
     protected BodyRequestBuilder digestMd5(final String digest) {
-        addDigest(digest, "md5");
-        return this;
+        return digest(digest, "md5");
     }
 
     /**
@@ -133,18 +150,7 @@ public abstract class BodyRequestBuilder extends
      * @return this builder
      */
     protected BodyRequestBuilder digestSha256(final String digest) {
-        addDigest(digest, "sha256");
-        return this;
-    }
-
-    private void addDigest(final String digest, final String alg) {
-        if (digest != null) {
-            if (digestJoiner == null) {
-                digestJoiner = new StringJoiner(", ");
-            }
-            digestJoiner.add(alg + "=" + digest);
-            request.setHeader(DIGEST, digestJoiner.toString());
-        }
+        return digest(digest, "sha256");
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.StringJoiner;
 
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.entity.InputStreamEntity;
@@ -37,6 +38,8 @@ import org.apache.http.entity.InputStreamEntity;
  */
 public abstract class BodyRequestBuilder extends
         RequestBuilder {
+
+    private StringJoiner digestJoiner;
 
     /**
      * Instantiate builder
@@ -98,10 +101,50 @@ public abstract class BodyRequestBuilder extends
      * @return this builder
      */
     protected BodyRequestBuilder digest(final String digest) {
-        if (digest != null) {
-            request.addHeader(DIGEST, "sha1=" + digest);
-        }
+        return digestSha1(digest);
+    }
+
+    /**
+     * Provide a SHA-1 checksum for the body of this request
+     * 
+     * @param digest sha-1 checksum to provide as the digest for the request body
+     * @return this builder
+     */
+    protected BodyRequestBuilder digestSha1(final String digest) {
+        addDigest(digest, "sha1");
         return this;
+    }
+
+    /**
+     * Provide a MD5 checksum for the body of this request
+     * 
+     * @param digest MD5 checksum to provide as the digest for the request body
+     * @return this builder
+     */
+    protected BodyRequestBuilder digestMd5(final String digest) {
+        addDigest(digest, "md5");
+        return this;
+    }
+
+    /**
+     * Provide a SHA-256 checksum for the body of this request
+     * 
+     * @param digest sha-256 checksum to provide as the digest for the request body
+     * @return this builder
+     */
+    protected BodyRequestBuilder digestSha256(final String digest) {
+        addDigest(digest, "sha256");
+        return this;
+    }
+
+    private void addDigest(final String digest, final String alg) {
+        if (digest != null) {
+            if (digestJoiner == null) {
+                digestJoiner = new StringJoiner(", ");
+            }
+            digestJoiner.add(alg + "=" + digest);
+            request.setHeader(DIGEST, digestJoiner.toString());
+        }
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -62,4 +62,24 @@ public class PatchBuilder extends BodyRequestBuilder {
     public PatchBuilder ifUnmodifiedSince(final String modified) {
         return (PatchBuilder) super.ifUnmodifiedSince(modified);
     }
+
+    @Override
+    public PatchBuilder digest(final String digest) {
+        return (PatchBuilder) super.digest(digest);
+    }
+
+    @Override
+    public PatchBuilder digestMd5(final String digest) {
+        return (PatchBuilder) super.digestMd5(digest);
+    }
+
+    @Override
+    public PatchBuilder digestSha1(final String digest) {
+        return (PatchBuilder) super.digestSha1(digest);
+    }
+
+    @Override
+    public PatchBuilder digestSha256(final String digest) {
+        return (PatchBuilder) super.digestSha256(digest);
+    }
 }

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -69,6 +69,11 @@ public class PatchBuilder extends BodyRequestBuilder {
     }
 
     @Override
+    public PatchBuilder digest(final String digest, final String alg) {
+        return (PatchBuilder) super.digest(digest, alg);
+    }
+
+    @Override
     public PatchBuilder digestMd5(final String digest) {
         return (PatchBuilder) super.digestMd5(digest);
     }

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -71,6 +71,21 @@ public class PostBuilder extends BodyRequestBuilder {
         return (PostBuilder) super.digest(digest);
     }
 
+    @Override
+    public PostBuilder digestMd5(final String digest) {
+        return (PostBuilder) super.digestMd5(digest);
+    }
+
+    @Override
+    public PostBuilder digestSha1(final String digest) {
+        return (PostBuilder) super.digestSha1(digest);
+    }
+
+    @Override
+    public PostBuilder digestSha256(final String digest) {
+        return (PostBuilder) super.digestSha256(digest);
+    }
+
     /**
      * Provide a content disposition header which will be used as the filename
      * 

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -72,6 +72,11 @@ public class PostBuilder extends BodyRequestBuilder {
     }
 
     @Override
+    public PostBuilder digest(final String digest, final String alg) {
+        return (PostBuilder) super.digest(digest, alg);
+    }
+
+    @Override
     public PostBuilder digestMd5(final String digest) {
         return (PostBuilder) super.digestMd5(digest);
     }

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -79,6 +79,11 @@ public class PutBuilder extends BodyRequestBuilder {
     }
 
     @Override
+    public PutBuilder digest(final String digest, final String alg) {
+        return (PutBuilder) super.digest(digest, alg);
+    }
+
+    @Override
     public PutBuilder digestMd5(final String digest) {
         return (PutBuilder) super.digestMd5(digest);
     }

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -78,6 +78,21 @@ public class PutBuilder extends BodyRequestBuilder {
         return (PutBuilder) super.digest(digest);
     }
 
+    @Override
+    public PutBuilder digestMd5(final String digest) {
+        return (PutBuilder) super.digestMd5(digest);
+    }
+
+    @Override
+    public PutBuilder digestSha1(final String digest) {
+        return (PutBuilder) super.digestSha1(digest);
+    }
+
+    @Override
+    public PutBuilder digestSha256(final String digest) {
+        return (PutBuilder) super.digestSha256(digest);
+    }
+
     /**
      * Set the prefer header for this request to lenient handling, to indicate that server-managed triples will not
      * be included in the request body.

--- a/src/test/java/org/fcrepo/client/PostBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PostBuilderTest.java
@@ -104,6 +104,26 @@ public class PostBuilderTest {
     }
 
     @Test
+    public void testWithBodyMultipleChecksums() throws Exception {
+        final InputStream bodyStream = mock(InputStream.class);
+
+        testBuilder.body(bodyStream, "plain/text")
+                .digest("checksum")
+                .digestSha256("checksum256")
+                .perform();
+
+        final ArgumentCaptor<HttpRequestBase> requestCaptor = ArgumentCaptor.forClass(HttpRequestBase.class);
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        final HttpEntity bodyEntity = request.getEntity();
+        assertEquals(bodyStream, bodyEntity.getContent());
+
+        assertEquals("plain/text", request.getFirstHeader(CONTENT_TYPE).getValue());
+        assertEquals("sha1=checksum, sha256=checksum256", request.getFirstHeader(DIGEST).getValue());
+    }
+
+    @Test
     public void testBodyNoType() throws Exception {
         final InputStream bodyStream = mock(InputStream.class);
 

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -134,6 +134,19 @@ public class FcrepoClientIT extends AbstractResourceIT {
     }
 
     @Test
+    public void testPostDigestMultipleChecksums() throws Exception {
+        final String bodyContent = "Hello world";
+
+        final FcrepoResponse response = client.post(new URI(serverAddress))
+                .body(new ByteArrayInputStream(bodyContent.getBytes()), "text/plain")
+                .digestSha1("7b502c3a1f48c8609ae212cdfb639dee39673f5e")
+                .digestSha256("1894a19c85ba153acbf743ac4e43fc004c891604b26f8c69e1e83ea2afc7c48f")
+                .perform();
+
+        assertEquals("Checksums rejected", CREATED.getStatusCode(), response.getStatusCode());
+    }
+
+    @Test
     public void testPut() throws Exception {
         final FcrepoResponse response = create();
 
@@ -329,6 +342,8 @@ public class FcrepoClientIT extends AbstractResourceIT {
         final String mimetype = "text/plain";
         final String bodyContent = "Hello world";
         final FcrepoResponse response = client.post(new URI(serverAddress))
+                .digestMd5("f0ef7081e1539ac00ef5b761b4fb01b3")
+                .digestSha1("7b502c3a1f48c8609ae212cdfb639dee39673f5e")
                 .body(new ByteArrayInputStream(bodyContent.getBytes()), mimetype)
                 .perform();
 


### PR DESCRIPTION
While attempting to pass an md5 checksum along with a binary I realized that the client didn't currently have a way to specify this (since its based around fcrepo 4.5).  This PR adds helper methods for the 3 supported digest types (and adds the missing digest method on the patch method).

Note, the added integration test passes, but the MD5 won't have any affect until the fcrepo-version is updated.  