### PR TITLE
Fcrepo 2407 v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.5.0</version>
+    <version>4.7.1</version>
   </parent>
 
   <groupId>org.fcrepo.client</groupId>
@@ -37,12 +37,12 @@
     <github.global.server>github</github.global.server>
 
     <!-- dependencies -->
-    <fcrepo.version>4.5.0</fcrepo.version>
+    <fcrepo.version>4.7.1</fcrepo.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang3.version>3.3.2</commons.lang3.version>
-    <grizzly.version>2.3.18</grizzly.version>
-    <httpclient.version>4.3.6</httpclient.version>
-    <jersey.version>2.15</jersey.version>
+    <grizzly.version>2.3.28</grizzly.version>
+    <httpclient.version>4.4.1</httpclient.version>
+    <jersey.version>2.24</jersey.version>
     <joda-time.version>2.9.2</joda-time.version>
     <logback.version>1.1.2</logback.version>
     <mockito.version>1.10.8</mockito.version>

--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -29,6 +29,8 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.StringJoiner;
 
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.entity.InputStreamEntity;
 
@@ -178,6 +180,19 @@ public abstract class BodyRequestBuilder extends
     protected BodyRequestBuilder ifMatch(final String etag) {
         if (etag != null) {
             request.setHeader(IF_MATCH, etag);
+        }
+        return this;
+    }
+
+    /**
+     * Provide an etag for the if-match header for this request
+     * 
+     * @param etag EntityTag to provide as the if-match header
+     * @return this builder
+     */
+    protected BodyRequestBuilder ifMatch(final EntityTag etag) {
+        if (etag != null) {
+            request.setHeader(IF_MATCH, "\"" + etag.getValue() + "\"");
         }
         return this;
     }

--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -95,11 +95,13 @@ public abstract class BodyRequestBuilder extends
     }
 
     /**
-     * Provide a SHA-1 checksum for the body of this request
+     * Provide a SHA-1 checksum for the body of this request.
      * 
+     * @deprecated Use {@link #digestSha1(java.lang.String)}.
      * @param digest sha-1 checksum to provide as the digest for the request body
      * @return this builder
      */
+    @Deprecated
     protected BodyRequestBuilder digest(final String digest) {
         return digestSha1(digest);
     }
@@ -124,7 +126,7 @@ public abstract class BodyRequestBuilder extends
     }
 
     /**
-     * Provide a SHA-1 checksum for the body of this request
+     * Provide a SHA-1 checksum for the body of this request.
      * 
      * @param digest sha-1 checksum to provide as the digest for the request body
      * @return this builder

--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;

--- a/src/main/java/org/fcrepo/client/CopyBuilder.java
+++ b/src/main/java/org/fcrepo/client/CopyBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.net.URI;

--- a/src/main/java/org/fcrepo/client/DeleteBuilder.java
+++ b/src/main/java/org/fcrepo/client/DeleteBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.net.URI;

--- a/src/main/java/org/fcrepo/client/FcrepoClient.java
+++ b/src/main/java/org/fcrepo/client/FcrepoClient.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/src/main/java/org/fcrepo/client/FcrepoHttpClientBuilder.java
+++ b/src/main/java/org/fcrepo/client/FcrepoHttpClientBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/org/fcrepo/client/FcrepoLink.java
+++ b/src/main/java/org/fcrepo/client/FcrepoLink.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/org/fcrepo/client/FcrepoOperationFailedException.java
+++ b/src/main/java/org/fcrepo/client/FcrepoOperationFailedException.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/org/fcrepo/client/FcrepoResponse.java
+++ b/src/main/java/org/fcrepo/client/FcrepoResponse.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toList;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DESCRIBED_BY;
+import static org.fcrepo.client.FedoraHeaderConstants.ETAG;
 import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.LOCATION;
 
@@ -32,6 +33,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.http.HeaderElement;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeader;
@@ -257,6 +261,19 @@ public class FcrepoResponse implements Closeable {
      */
     public void setLocation(final URI location) {
         this.location = location;
+    }
+
+    /**
+     * Get the entity tag for this response
+     * 
+     * @return the entity tag object
+     */
+    public EntityTag getEtag() {
+        String etagValue = getHeaderValue(ETAG);
+        if (etagValue == null) {
+            return null;
+        }
+        return EntityTag.valueOf(etagValue);
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/FcrepoResponse.java
+++ b/src/main/java/org/fcrepo/client/FcrepoResponse.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.util.Collections.emptyList;

--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 /**

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -28,6 +28,8 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 
@@ -166,6 +168,19 @@ public class GetBuilder extends
     public GetBuilder ifNoneMatch(final String etag) {
         if (etag != null) {
             request.setHeader(IF_NONE_MATCH, etag);
+        }
+        return this;
+    }
+
+    /**
+     * Provide an etag for the if-none-match header for this request
+     * 
+     * @param etag EntityTag to provide as the if-none-match header
+     * @return this builder
+     */
+    public GetBuilder ifNoneMatch(final EntityTag etag) {
+        if (etag != null) {
+            request.setHeader(IF_NONE_MATCH, "\"" + etag.getValue() + "\"");
         }
         return this;
     }

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT;

--- a/src/main/java/org/fcrepo/client/HeadBuilder.java
+++ b/src/main/java/org/fcrepo/client/HeadBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.net.URI;

--- a/src/main/java/org/fcrepo/client/HttpMethods.java
+++ b/src/main/java/org/fcrepo/client/HttpMethods.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.net.URI;

--- a/src/main/java/org/fcrepo/client/MoveBuilder.java
+++ b/src/main/java/org/fcrepo/client/MoveBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.DESTINATION;

--- a/src/main/java/org/fcrepo/client/OptionsBuilder.java
+++ b/src/main/java/org/fcrepo/client/OptionsBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.net.URI;

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import java.io.InputStream;

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -20,6 +20,8 @@ package org.fcrepo.client;
 import java.io.InputStream;
 import java.net.URI;
 
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.http.client.methods.HttpRequestBase;
 
 /**
@@ -56,6 +58,11 @@ public class PatchBuilder extends BodyRequestBuilder {
 
     @Override
     public PatchBuilder ifMatch(final String etag) {
+        return (PatchBuilder) super.ifMatch(etag);
+    }
+
+    @Override
+    public PatchBuilder ifMatch(final EntityTag etag) {
         return (PatchBuilder) super.ifMatch(etag);
     }
 

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -63,6 +63,7 @@ public class PatchBuilder extends BodyRequestBuilder {
         return (PatchBuilder) super.ifUnmodifiedSince(modified);
     }
 
+    @Deprecated
     @Override
     public PatchBuilder digest(final String digest) {
         return (PatchBuilder) super.digest(digest);

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -66,6 +66,7 @@ public class PostBuilder extends BodyRequestBuilder {
         return (PostBuilder) super.body(stream);
     }
 
+    @Deprecated
     @Override
     public PostBuilder digest(final String digest) {
         return (PostBuilder) super.digest(digest);

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.http.client.methods.HttpRequestBase;
 
 /**
@@ -66,6 +68,11 @@ public class PutBuilder extends BodyRequestBuilder {
 
     @Override
     public PutBuilder ifMatch(final String etag) {
+        return (PutBuilder) super.ifMatch(etag);
+    }
+
+    @Override
+    public PutBuilder ifMatch(final EntityTag etag) {
         return (PutBuilder) super.ifMatch(etag);
     }
 

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -73,6 +73,7 @@ public class PutBuilder extends BodyRequestBuilder {
         return (PutBuilder) super.ifUnmodifiedSince(modified);
     }
 
+    @Deprecated
     @Override
     public PutBuilder digest(final String digest) {
         return (PutBuilder) super.digest(digest);

--- a/src/main/java/org/fcrepo/client/RequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/RequestBuilder.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static org.slf4j.LoggerFactory.getLogger;

--- a/src/test/java/org/fcrepo/client/ConnectionManagementTest.java
+++ b/src/test/java/org/fcrepo/client/ConnectionManagementTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/ConnectionManagementTest.java
+++ b/src/test/java/org/fcrepo/client/ConnectionManagementTest.java
@@ -219,7 +219,7 @@ public class ConnectionManagementTest {
     public void connectionReleasedOnEntityBodyClose() {
         final int expectedCount = (int) Stream.of(HttpMethods.values()).filter(m -> m.entity).count();
         final AtomicInteger actualCount = new AtomicInteger(0);
-        final MockHttpExpectations.Uris uri = uris.uri200;
+        final MockHttpExpectations.Uris uri = uris.uri200RespBody;
 
         Stream.of(HttpMethods.values())
                 .filter(method -> method.entity)
@@ -240,7 +240,7 @@ public class ConnectionManagementTest {
     public void connectionReleasedOnEntityBodyRead() {
         final int expectedCount = (int) Stream.of(HttpMethods.values()).filter(m -> m.entity).count();
         final AtomicInteger actualCount = new AtomicInteger(0);
-        final MockHttpExpectations.Uris uri = uris.uri200;
+        final MockHttpExpectations.Uris uri = uris.uri200RespBody;
 
         Stream.of(HttpMethods.values())
                 .filter(method -> method.entity)
@@ -262,7 +262,7 @@ public class ConnectionManagementTest {
     public void connectionNotReleasedWhenEntityBodyIgnored() {
         final int expectedCount = (int) Stream.of(HttpMethods.values()).filter(m -> m.entity).count();
         final AtomicInteger actualCount = new AtomicInteger(0);
-        final MockHttpExpectations.Uris uri = uris.uri200;
+        final MockHttpExpectations.Uris uri = uris.uri200RespBody;
 
         Stream.of(HttpMethods.values())
                 .filter(method -> method.entity)
@@ -274,6 +274,27 @@ public class ConnectionManagementTest {
         assertEquals("Expected to make " + expectedCount + " connections; made " + actualCount.get(),
                 expectedCount, actualCount.get());
         verifyConnectionRequestedButNotClosed(actualCount.get(), connectionManager);
+    }
+
+    /**
+     * Demonstrates that are connections are released when the FcrepoClient receives an empty response body.
+     */
+    @Test
+    public void connectionReleasedOnEmptyBody() {
+        final int expectedCount = (int) Stream.of(HttpMethods.values()).filter(m -> m.entity).count();
+        final AtomicInteger actualCount = new AtomicInteger(0);
+        final MockHttpExpectations.Uris uri = uris.uri200;
+
+        Stream.of(HttpMethods.values())
+                .filter(method -> method.entity)
+                .forEach(method -> {
+                    connect(client, uri, method, null);
+                    actualCount.getAndIncrement();
+                });
+
+        assertEquals("Expected to make " + expectedCount + " connections; made " + actualCount.get(),
+                expectedCount, actualCount.get());
+        verifyConnectionRequestedAndClosed(actualCount.get(), connectionManager);
     }
 
     /**

--- a/src/test/java/org/fcrepo/client/FcrepoClientAuthTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoClientAuthTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/FcrepoClientErrorTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoClientErrorTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/FcrepoClientTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoClientTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/FcrepoLinkTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoLinkTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/FcrepoResponseTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoResponseTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/GetBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/GetBuilderTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/HeadBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HeadBuilderTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/HttpMethodsTest.java
+++ b/src/test/java/org/fcrepo/client/HttpMethodsTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/MockHttpExpectations.java
+++ b/src/test/java/org/fcrepo/client/MockHttpExpectations.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/MockHttpExpectations.java
+++ b/src/test/java/org/fcrepo/client/MockHttpExpectations.java
@@ -15,13 +15,13 @@
  */
 package org.fcrepo.client;
 
-import org.apache.http.HttpStatus;
-import org.mockserver.client.server.MockServerClient;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 import java.net.URI;
 
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
+import org.apache.http.HttpStatus;
+import org.mockserver.client.server.MockServerClient;
 
 /**
  * Expectations for the Mock Http Server
@@ -42,11 +42,18 @@ public final class MockHttpExpectations {
 
     final static class Uris {
         int statusCode;
+        String suffix;
         String path;
 
         Uris(final int statusCode) {
             this.statusCode = statusCode;
             this.path = "/uri/" + statusCode;
+        }
+
+        Uris(final int statusCode, final String suffix) {
+            this.statusCode = statusCode;
+            this.suffix = suffix;
+            this.path = "/uri/" + statusCode + suffix;
         }
 
         URI asUri() {
@@ -59,7 +66,7 @@ public final class MockHttpExpectations {
         }
     }
 
-    final static class SupportedUris {
+    public final static class SupportedUris {
 
         /**
          * A request URI that will return a 500.
@@ -76,6 +83,10 @@ public final class MockHttpExpectations {
          */
         final Uris uri200 = new Uris(200);
 
+        /**
+         * A request URI that will return a 200 with a text response body.
+         */
+        final public Uris uri200RespBody = new Uris(200, "RespBody");
     }
 
     /**
@@ -112,6 +123,13 @@ public final class MockHttpExpectations {
                         .withStatusCode(HttpStatus.SC_OK)
         );
 
+        mockServerClient.when(
+                request()
+                        .withPath("/uri/200RespBody")
+        ).respond(
+                response("Response body")
+                        .withStatusCode(HttpStatus.SC_OK)
+        );
     }
 
 }

--- a/src/test/java/org/fcrepo/client/MoveBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/MoveBuilderTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/PostBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PostBuilderTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/PutBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PutBuilderTest.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client;
 
 import static java.net.URI.create;

--- a/src/test/java/org/fcrepo/client/TestUtils.java
+++ b/src/test/java/org/fcrepo/client/TestUtils.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/org/fcrepo/client/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/client/integration/AbstractResourceIT.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client.integration;
 
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/org/fcrepo/client/integration/FcrepoAuthenticationIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoAuthenticationIT.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client.integration;
 
 import static javax.ws.rs.core.Response.Status.CREATED;

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -1,9 +1,11 @@
-/**
- * Copyright 2015 DuraSpace, Inc.
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -13,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.fcrepo.client.integration;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -45,6 +45,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
 
+import javax.ws.rs.core.EntityTag;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.client.utils.DateUtils;
 import org.fcrepo.client.FcrepoClient;
@@ -177,8 +179,7 @@ public class FcrepoClientIT extends AbstractResourceIT {
         final FcrepoResponse response = create();
 
         // Get the etag of the nearly created object
-        String etag = response.getHeaderValue(ETAG);
-        etag = etag.substring(2, etag.length());
+        final EntityTag etag = response.getEtag();
 
         // Retrieve the body of the resource so we can modify it
         String body = getTurtle(url);
@@ -266,8 +267,7 @@ public class FcrepoClientIT extends AbstractResourceIT {
     public void testPatchEtagUpdated() throws Exception {
         // Create object
         final FcrepoResponse createResp = create();
-        String createdEtag = createResp.getHeaderValue(ETAG);
-        createdEtag = createdEtag.substring(2, createdEtag.length());
+        final EntityTag createdEtag = createResp.getEtag();
 
         final InputStream body = new ByteArrayInputStream(sparqlUpdate.getBytes());
 
@@ -277,11 +277,11 @@ public class FcrepoClientIT extends AbstractResourceIT {
                 .ifMatch(createdEtag)
                 .perform();
 
-        String updateEtag = response.getHeaderValue(ETAG);
-        updateEtag = updateEtag.substring(2, updateEtag.length());
+        final EntityTag updatedEtag = EntityTag.valueOf(response.getHeaderValue(ETAG));
 
         assertEquals(NO_CONTENT.getStatusCode(), response.getStatusCode());
-        assertNotEquals("Etag did not change after patch", createdEtag, updateEtag);
+        assertNotEquals("Etag did not change after patch",
+                createdEtag, updatedEtag);
     }
 
     @Test
@@ -338,7 +338,7 @@ public class FcrepoClientIT extends AbstractResourceIT {
 
         assertEquals(NOT_MODIFIED.getStatusCode(), modResp.getStatusCode());
 
-        final String originalEtag = response.getHeaderValue(ETAG);
+        final EntityTag originalEtag = response.getEtag();
         final FcrepoResponse etagResp = client.get(url)
                 .ifNoneMatch(originalEtag)
                 .perform();


### PR DESCRIPTION
Includes one extra commit over FCREPO-2407, which adds FcrepoResponse.getEtag(), and adds setter methods which take entityTag objects in order to handle the change from strong to weak etags in responses.