### PR TITLE
Fix return type of prefer-lenient

### DIFF
--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -106,7 +106,7 @@ public class PutBuilder extends BodyRequestBuilder {
      *
      * @return this builder
      */
-    public BodyRequestBuilder preferLenient() {
+    public PutBuilder preferLenient() {
         request.setHeader(PREFER, "handling=lenient; received=\"minimal\"");
         return this;
     }


### PR DESCRIPTION
`PutBuilder.preferLenient()` was incorrectly returning itself as a `BodyRequestBuilder`, resulting in undesirable behaviors when using the fluent API.