### PR TITLE
Fcrepo-2943 - Add external content method for POST and PUT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <grizzly.version>2.4.3</grizzly.version>
     <httpclient.version>4.5.6</httpclient.version>
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
+    <javax.ws.rs-api.vesion>2.0.1</javax.ws.rs-api.vesion>
     <jersey.version>2.25.1</jersey.version>
     <joda-time.version>2.10.1</joda-time.version>
     <logback.version>1.2.3</logback.version>
@@ -86,6 +87,12 @@
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>${javax.ws.rs-api.vesion}</version>
     </dependency>
 
     <!-- logging -->

--- a/src/main/java/org/fcrepo/client/ExternalContentHandling.java
+++ b/src/main/java/org/fcrepo/client/ExternalContentHandling.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+/**
+ * Constants for external content handling defined by the Fedora specification,
+ * used to determine how to process the external content URI.
+ *
+ * @author bbpennel
+ *
+ */
+public class ExternalContentHandling {
+
+    /**
+     * Requests that the server dereference the external content URI and treat that as if
+     * it were the entity body of the request.
+     */
+    public static final String COPY = "copy";
+
+    /**
+     * Requests that the server record the location of the external content and handle
+     * requests for that content using HTTP redirect responses with the Content-Location
+     * header specifying the external content location
+     */
+    public static final String REDIRECT = "redirect";
+
+    /**
+     * Requests that the server record the location of the external content and handle
+     * requests for that content by proxying.
+     */
+    public static final String PROXY = "proxy";
+
+    private ExternalContentHandling() {
+    }
+}

--- a/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+/**
+ * Link header values used in the Fedora specification.
+ *
+ * @author bbpennel
+ */
+public class LinkHeaderConstants {
+
+    // handling parameter for external content Links
+    public static final String EXTERNAL_CONTENT_HANDLING = "handling";
+
+    // rel value for external content URI for binaries
+    public static final String EXTERNAL_CONTENT_REL = "http://fedora.info/definitions/fcrepo#ExternalContent";
+
+    private LinkHeaderConstants() {
+    }
+}

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -32,14 +32,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 /**
  * Builds a post request for interacting with the Fedora HTTP API in order to create a new resource within an LDP
  * container.
- * 
+ *
  * @author bbpennel
  */
 public class PostBuilder extends BodyRequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
@@ -65,6 +65,11 @@ public class PostBuilder extends BodyRequestBuilder {
     @Override
     public PostBuilder body(final InputStream stream) {
         return (PostBuilder) super.body(stream);
+    }
+
+    @Override
+    public PostBuilder externalContent(final URI contentURI, final String contentType, final String handling) {
+        return (PostBuilder) super.externalContent(contentURI, contentType, handling);
     }
 
     @Deprecated
@@ -95,7 +100,7 @@ public class PostBuilder extends BodyRequestBuilder {
 
     /**
      * Provide a content disposition header which will be used as the filename
-     * 
+     *
      * @param filename the name of the file being provided in the body of the request
      * @return this builder
      * @throws FcrepoOperationFailedException if unable to encode filename
@@ -104,7 +109,7 @@ public class PostBuilder extends BodyRequestBuilder {
         try {
             final String f = (filename != null) ? "; filename=\"" + URLEncoder.encode(filename, "utf-8") + "\"" : "";
             request.addHeader(CONTENT_DISPOSITION, "attachment" + f);
-        } catch (UnsupportedEncodingException e) {
+        } catch (final UnsupportedEncodingException e) {
             throw new FcrepoOperationFailedException(request.getURI(), -1, e.getMessage());
         }
         return this;
@@ -112,7 +117,7 @@ public class PostBuilder extends BodyRequestBuilder {
 
     /**
      * Provide a suggested name for the new child resource, which the repository may ignore.
-     * 
+     *
      * @param slug value to supply as the slug header
      * @return this builder
      */

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -32,14 +32,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 /**
  * Builds a PUT request for interacting with the Fedora HTTP API in order to create a resource with a specified path,
  * or replace the triples associated with a resource with the triples provided in the request body.
- * 
+ *
  * @author bbpennel
  */
 public class PutBuilder extends BodyRequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
@@ -60,6 +60,11 @@ public class PutBuilder extends BodyRequestBuilder {
     @Override
     public PutBuilder body(final File file, final String contentType) throws IOException {
         return (PutBuilder) super.body(file, contentType);
+    }
+
+    @Override
+    public PutBuilder externalContent(final URI contentURI, final String contentType, final String handling) {
+        return (PutBuilder) super.externalContent(contentURI, contentType, handling);
     }
 
     @Override
@@ -114,7 +119,7 @@ public class PutBuilder extends BodyRequestBuilder {
         try {
             final String f = (filename != null) ? "; filename=\"" + URLEncoder.encode(filename, "utf-8") + "\"" : "";
             request.addHeader(CONTENT_DISPOSITION, "attachment" + f);
-        } catch (UnsupportedEncodingException e) {
+        } catch (final UnsupportedEncodingException e) {
             throw new FcrepoOperationFailedException(request.getURI(), -1, e.getMessage());
         }
         return this;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2943

# What does this Pull Request do?
Allows external content to be added via the client

# What's new?
* Adds constants to help with creation of external content
* Adds dependency on javax.ws.rs-api for Link headers 

# How should this be tested?

`mvn clean install`


# Additional Notes:
I will leave it up to the reviewer whether including the new dependency is worthwhile just to not have to reimplement the Link and Link.Builder classes.

I also gave up on trying to fight eclipse over the whitespace on blank lines in javadoc, it will get cleared by someone's IDE eventually.

# Interested parties
@awoods @dbernstein 
