### PR TITLE
Fcrepo-2945 - Create mementos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <javax.ws.rs-api.vesion>2.0.1</javax.ws.rs-api.vesion>
     <jersey.version>2.25.1</jersey.version>
-    <joda-time.version>2.10.1</joda-time.version>
     <logback.version>1.2.3</logback.version>
     <mockito.version>2.23.0</mockito.version>
     <mockserver.version>5.4.1</mockserver.version>
@@ -239,14 +238,6 @@
       <version>${fcrepo.version}</version>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>${joda-time.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -87,12 +87,6 @@
       <artifactId>httpclient</artifactId>
       <version>${httpclient.version}</version>
     </dependency>
-    
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>${javax.ws.rs-api.vesion}</version>
-    </dependency>
 
     <!-- logging -->
     <dependency>

--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -21,9 +21,9 @@ import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_UNMODIFIED_SINCE;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.LinkHeaderConstants.EXTERNAL_CONTENT_HANDLING;
 import static org.fcrepo.client.LinkHeaderConstants.EXTERNAL_CONTENT_REL;
-import static javax.ws.rs.core.HttpHeaders.LINK;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,12 +32,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.StringJoiner;
 
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Link.Builder;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.entity.InputStreamEntity;
+import org.fcrepo.client.FcrepoLink.Builder;
 
 /**
  * Request builder which includes a body component
@@ -114,7 +112,7 @@ public abstract class BodyRequestBuilder extends
      */
     protected BodyRequestBuilder externalContent(final URI contentURI, final String contentType,
             final String handling) {
-        final Builder linkBuilder = Link.fromUri(contentURI)
+        final Builder linkBuilder = FcrepoLink.fromUri(contentURI)
             .rel(EXTERNAL_CONTENT_REL)
             .param(EXTERNAL_CONTENT_HANDLING, handling);
 

--- a/src/main/java/org/fcrepo/client/FcrepoClient.java
+++ b/src/main/java/org/fcrepo/client/FcrepoClient.java
@@ -96,9 +96,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to which to PUT
      * @return a put request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public PutBuilder put(final URI url) throws FcrepoOperationFailedException {
+    public PutBuilder put(final URI url) {
         return new PutBuilder(url, this);
     }
 
@@ -107,9 +106,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to which to PATCH
      * @return a patch request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public PatchBuilder patch(final URI url) throws FcrepoOperationFailedException {
+    public PatchBuilder patch(final URI url) {
         return new PatchBuilder(url, this);
     }
 
@@ -118,9 +116,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to which to POST
      * @return a post request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public PostBuilder post(final URI url) throws FcrepoOperationFailedException {
+    public PostBuilder post(final URI url) {
         return new PostBuilder(url, this);
     }
 
@@ -129,9 +126,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the LDPCv in which to create the LDPRm.
      * @return a memento creation request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public OriginalMementoBuilder createMemento(final URI url) throws FcrepoOperationFailedException {
+    public OriginalMementoBuilder createMemento(final URI url) {
         return new OriginalMementoBuilder(url, this);
     }
 
@@ -142,10 +138,8 @@ public class FcrepoClient {
      * @param url the URL of the LDPCv in which to create the LDPRm.
      * @param mementoInstant the memento datetime as an Instant.
      * @return a memento creation request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public HistoricMementoBuilder createMemento(final URI url, final Instant mementoInstant)
-            throws FcrepoOperationFailedException {
+    public HistoricMementoBuilder createMemento(final URI url, final Instant mementoInstant) {
         return new HistoricMementoBuilder(url, this, mementoInstant);
     }
 
@@ -156,10 +150,8 @@ public class FcrepoClient {
      * @param url the URL of the LDPCv in which to create the LDPRm.
      * @param mementoDatetime the RFC1123 formatted memento datetime.
      * @return a memento creation request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public HistoricMementoBuilder createMemento(final URI url, final String mementoDatetime)
-            throws FcrepoOperationFailedException {
+    public HistoricMementoBuilder createMemento(final URI url, final String mementoDatetime) {
         return new HistoricMementoBuilder(url, this, mementoDatetime);
     }
 
@@ -168,9 +160,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to which to DELETE
      * @return a delete request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public DeleteBuilder delete(final URI url) throws FcrepoOperationFailedException {
+    public DeleteBuilder delete(final URI url) {
         return new DeleteBuilder(url, this);
     }
 
@@ -180,9 +171,8 @@ public class FcrepoClient {
      * @param source url of the resource to copy
      * @param destination url of the location for the copy
      * @return a copy request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public CopyBuilder copy(final URI source, final URI destination) throws FcrepoOperationFailedException {
+    public CopyBuilder copy(final URI source, final URI destination) {
         return new CopyBuilder(source, destination, this);
     }
 
@@ -192,9 +182,8 @@ public class FcrepoClient {
      * @param source url of the resource to move
      * @param destination url of the new location for the resource
      * @return a move request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public MoveBuilder move(final URI source, final URI destination) throws FcrepoOperationFailedException {
+    public MoveBuilder move(final URI source, final URI destination) {
         return new MoveBuilder(source, destination, this);
     }
 
@@ -203,9 +192,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to which to GET
      * @return a get request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public GetBuilder get(final URI url) throws FcrepoOperationFailedException {
+    public GetBuilder get(final URI url) {
         return new GetBuilder(url, this);
     }
 
@@ -214,9 +202,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to make the HEAD request on.
      * @return a HEAD request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public HeadBuilder head(final URI url) throws FcrepoOperationFailedException {
+    public HeadBuilder head(final URI url) {
         return new HeadBuilder(url, this);
     }
 
@@ -225,9 +212,8 @@ public class FcrepoClient {
      *
      * @param url the URL of the resource to make the OPTIONS request on.
      * @return a OPTIONS request builder object
-     * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
-    public OptionsBuilder options(final URI url) throws FcrepoOperationFailedException {
+    public OptionsBuilder options(final URI url) {
         return new OptionsBuilder(url, this);
     }
 

--- a/src/main/java/org/fcrepo/client/FcrepoResponse.java
+++ b/src/main/java/org/fcrepo/client/FcrepoResponse.java
@@ -21,10 +21,11 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
-import static org.fcrepo.client.FedoraHeaderConstants.DESCRIBED_BY;
 import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.LOCATION;
-
+import static org.fcrepo.client.LinkHeaderConstants.DESCRIBEDBY_REL;
+import static org.fcrepo.client.LinkHeaderConstants.TYPE_REL;
+import javax.ws.rs.core.Link;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -227,6 +228,28 @@ public class FcrepoResponse implements Closeable {
     }
 
     /**
+     * Return true if the response represents a resource with the given type
+     *
+     * @param typeString String containing the URI of the type
+     * @return true if the type is present.
+     */
+    public boolean hasType(final String typeString) {
+        return hasType(URI.create(typeString));
+    }
+
+    /**
+     * Return true if the response represents a resource with the given type
+     *
+     * @param typeUri URI of the type
+     * @return true if the type is present.
+     */
+    public boolean hasType(final URI typeUri) {
+        return getHeaderValues(LINK).stream()
+                .map(Link::valueOf)
+                .anyMatch(l -> l.getRel().equals(TYPE_REL) && l.getUri().equals(typeUri));
+    }
+
+    /**
      * location getter
      *
      * @return the location of a related resource
@@ -240,7 +263,7 @@ public class FcrepoResponse implements Closeable {
             }
             // Fall back to retrieving from the described by link
             if (location == null) {
-                final List<URI> links = getLinkHeaders(DESCRIBED_BY);
+                final List<URI> links = getLinkHeaders(DESCRIBEDBY_REL);
                 if (links != null && links.size() == 1) {
                     location = links.get(0);
                 }

--- a/src/main/java/org/fcrepo/client/FcrepoResponse.java
+++ b/src/main/java/org/fcrepo/client/FcrepoResponse.java
@@ -25,7 +25,6 @@ import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.LOCATION;
 import static org.fcrepo.client.LinkHeaderConstants.DESCRIBEDBY_REL;
 import static org.fcrepo.client.LinkHeaderConstants.TYPE_REL;
-import javax.ws.rs.core.Link;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -245,7 +244,7 @@ public class FcrepoResponse implements Closeable {
      */
     public boolean hasType(final URI typeUri) {
         return getHeaderValues(LINK).stream()
-                .map(Link::valueOf)
+                .map(FcrepoLink::new)
                 .anyMatch(l -> l.getRel().equals(TYPE_REL) && l.getUri().equals(typeUri));
     }
 

--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -19,7 +19,7 @@ package org.fcrepo.client;
 
 /**
  * Header constants used in calls to the Fedora API
- * 
+ *
  * @author bbpennel
  */
 public class FedoraHeaderConstants {
@@ -63,6 +63,11 @@ public class FedoraHeaderConstants {
     public static final String DESTINATION = "Destination";
 
     public static final String LINK = "Link";
+
+    /**
+     * Datetime for a memento, either provided when creating the memento or returned when retrieving one.
+     */
+    public static final String MEMENTO_DATETIME = "Memento-Datetime";
 
     private FedoraHeaderConstants() {
     }

--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -24,8 +24,6 @@ package org.fcrepo.client;
  */
 public class FedoraHeaderConstants {
 
-    public static final String DESCRIBED_BY = "describedby";
-
     public static final String CONTENT_TYPE = "Content-Type";
 
     public static final String CONTENT_DISPOSITION = "Content-Disposition";

--- a/src/main/java/org/fcrepo/client/FedoraTypes.java
+++ b/src/main/java/org/fcrepo/client/FedoraTypes.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+/**
+ * Helper constants for resource types used in the Fedora specification.
+ *
+ * @author bbpennel
+ */
+public class FedoraTypes {
+
+    // Type representing a Memento TimeGate
+    public final static String MEMENTO_TIME_GATE_TYPE = "http://mementoweb.org/ns#TimeGate";
+
+    // Type representing a Memento TimeMap (LDPCv)
+    public final static String MEMENTO_TIME_MAP_TYPE = "http://mementoweb.org/ns#TimeMap";
+
+    // Type representing a Memento original resource (LDPRv)
+    public final static String MEMENTO_ORIGINAL_TYPE = "http://mementoweb.org/ns#OriginalResource";
+
+    // Type representing a Memento (LDPRm)
+    public final static String MEMENTO_TYPE = "http://mementoweb.org/ns#Memento";
+
+    private FedoraTypes() {
+    }
+}

--- a/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
+++ b/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
@@ -51,8 +51,8 @@ public class HistoricMementoBuilder extends PostBuilder {
     /**
      * Instantiate builder.
      *
-     * @param uri
-     * @param client
+     * @param uri uri of the resource this request is being made to
+     * @param client the client
      * @param mementoDatetime RFC1123 formatted date to use for the memento-datetime
      */
     public HistoricMementoBuilder(final URI uri, final FcrepoClient client, final String mementoDatetime) {

--- a/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
+++ b/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static org.fcrepo.client.FedoraHeaderConstants.MEMENTO_DATETIME;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Builds a POST request for creating a memento (LDPRm) with the state given in the request body
+ * and the datetime given in the Memento-Datetime request header.
+ *
+ * @author bbpennel
+ */
+public class HistoricMementoBuilder extends PostBuilder {
+
+    private static DateTimeFormatter UTC_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
+
+    /**
+     * Instantiate builder
+     *
+     * @param uri uri of the resource this request is being made to
+     * @param client the client
+     * @param mementoInstant Instant to use for the memento-datetime
+     */
+    public HistoricMementoBuilder(final URI uri, final FcrepoClient client, final Instant mementoInstant) {
+        super(uri, client);
+        final String rfc1123Datetime = UTC_RFC_1123_FORMATTER.format(mementoInstant);
+        request.setHeader(MEMENTO_DATETIME, rfc1123Datetime);
+    }
+
+    /**
+     * Instantiate builder.
+     *
+     * @param uri
+     * @param client
+     * @param mementoDatetime RFC1123 formatted date to use for the memento-datetime
+     */
+    public HistoricMementoBuilder(final URI uri, final FcrepoClient client, final String mementoDatetime) {
+        super(uri, client);
+        // Parse the datetime to ensure that it is in RFC1123 format
+        UTC_RFC_1123_FORMATTER.parse(mementoDatetime);
+        request.setHeader(MEMENTO_DATETIME, mementoDatetime);
+    }
+}

--- a/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
@@ -30,6 +30,21 @@ public class LinkHeaderConstants {
     // rel value for external content URI for binaries
     public static final String EXTERNAL_CONTENT_REL = "http://fedora.info/definitions/fcrepo#ExternalContent";
 
+    // rel for identifying the ldpcv for a ldprv
+    public static final String MEMENTO_TIME_MAP_REL = "timemap";
+
+    // rel for identifying the timegate of an ldprv
+    public static final String MEMENTO_TIME_GATE_REL = "timegate";
+
+    // rel for identifying an ldprv
+    public static final String MEMENTO_ORIGINAL_REL = "original";
+
+    // rel for link header representing the type or interaction model of the object
+    public static final String TYPE_REL = "type";
+
+    // rel identifying the RDF resource describing this resource
+    public static final String DESCRIBEDBY_REL = "describedby";
+
     private LinkHeaderConstants() {
     }
 }

--- a/src/main/java/org/fcrepo/client/OriginalMementoBuilder.java
+++ b/src/main/java/org/fcrepo/client/OriginalMementoBuilder.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import java.net.URI;
+
+import org.apache.http.client.methods.HttpRequestBase;
+
+/**
+ * Builds a POST request for creating a memento (LDPRm) from the current state of an LDPRv.
+ *
+ * @author bbpennel
+ */
+public class OriginalMementoBuilder extends RequestBuilder {
+
+    /**
+     * Instantiate builder
+     *
+     * @param uri uri of the resource this request is being made to
+     * @param client the client
+     */
+    protected OriginalMementoBuilder(final URI uri, final FcrepoClient client) {
+        super(uri, client);
+    }
+
+    @Override
+    protected HttpRequestBase createRequest() {
+        return HttpMethods.POST.createRequest(targetUri);
+    }
+
+}

--- a/src/test/java/org/fcrepo/client/FcrepoClientTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoClientTest.java
@@ -181,6 +181,19 @@ public class FcrepoClientTest {
         assertEquals(response.getBody(), null);
     }
 
+    @Test
+    public void testHeadersCaseInsensitive() throws Exception {
+        final int status = 200;
+        final URI uri = create(baseUrl);
+
+        doSetupMockRequest(TEXT_TURTLE, null, status);
+
+        final FcrepoResponse response = testClient.head(uri).perform();
+
+        // Verify that the case of header names returned by server doesn't impact retrieval
+        assertEquals(response.getHeaderValue("content-type"), TEXT_TURTLE);
+    }
+
     @Test(expected = FcrepoOperationFailedException.class)
     public void testHeadError() throws IOException, FcrepoOperationFailedException {
         doSetupMockRequest(TEXT_TURTLE, null, 404);

--- a/src/test/java/org/fcrepo/client/FcrepoLinkTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoLinkTest.java
@@ -20,8 +20,12 @@ package org.fcrepo.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.fcrepo.client.LinkHeaderConstants.DESCRIBEDBY_REL;
+import static org.fcrepo.client.LinkHeaderConstants.MEMENTO_ORIGINAL_REL;
+import static org.fcrepo.client.LinkHeaderConstants.MEMENTO_TIME_MAP_REL;
 
 import java.net.URI;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,66 +37,65 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class FcrepoLinkTest {
 
+    private static final String TEST_URI = "http://localhost/rest/a/b/c";
+
+    private static final String MULTI_LINK_HEADER =
+            "<http://a.example.org/>; rel=\"original\", " +
+            "<http://arxiv.example.net/timemap/http://a.example.org/>" +
+            "; rel=\"timemap\"; type=\"application/link-format\"" +
+            "; from=\"Tue, 15 Sep 2000 11:28:26 GMT\"" +
+            "; until=\"Wed, 20 Jan 2010 09:34:33 GMT\"";
+
     @Test
     public void testLink() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("<%s>; rel=\"%s\"", url, rel);
+        final String header = String.format("<%s>; rel=\"%s\"", TEST_URI, DESCRIBEDBY_REL);
         final FcrepoLink link = new FcrepoLink(header);
-        assertEquals(URI.create(url), link.getUri());
-        assertEquals(url, link.getUri().toString());
-        assertEquals(rel, link.getRel());
+        assertEquals(URI.create(TEST_URI), link.getUri());
+        assertEquals(TEST_URI, link.getUri().toString());
+        assertEquals(DESCRIBEDBY_REL, link.getRel());
     }
 
     @Test
     public void testLinkNoQuotes() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("<%s>; rel=%s", url, rel);
+        final String header = String.format("<%s>; rel=%s", TEST_URI, DESCRIBEDBY_REL);
         final FcrepoLink link = new FcrepoLink(header);
-        assertEquals(URI.create(url), link.getUri());
-        assertEquals(url, link.getUri().toString());
-        assertEquals(rel, link.getRel());
+        assertEquals(URI.create(TEST_URI), link.getUri());
+        assertEquals(TEST_URI, link.getUri().toString());
+        assertEquals(DESCRIBEDBY_REL, link.getRel());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLinkNoBrackets() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("%s; rel=%s", url, rel);
+        final String header = String.format("%s; rel=%s", TEST_URI, DESCRIBEDBY_REL);
         new FcrepoLink(header);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLinkBadBrackets1() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("<%s; rel=%s", url, rel);
+        final String header = String.format("<%s; rel=%s", TEST_URI, DESCRIBEDBY_REL);
         new FcrepoLink(header);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testLinkBadBrackets2() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("%s>; rel=%s", url, rel);
+        final String header = String.format("%s>; rel=%s", TEST_URI, DESCRIBEDBY_REL);
         new FcrepoLink(header);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testLinkBadQuotes() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("<%s>; rel=\"%s", url, rel);
-        final FcrepoLink link = new FcrepoLink(header);
-        assertEquals(URI.create(url), link.getUri());
-        assertNull("Incorrectly quoted parameter should return null", link.getRel());
+        final String header = String.format("<%s>; rel=\"%s", TEST_URI, DESCRIBEDBY_REL);
+        new FcrepoLink(header);
     }
-
 
     @Test(expected = IllegalArgumentException.class)
     public void testNullLink() {
         new FcrepoLink(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptyLink() {
+        new FcrepoLink(" ");
     }
 
     @Test
@@ -116,6 +119,18 @@ public class FcrepoLinkTest {
         final FcrepoLink link = new FcrepoLink("<a>; foo=bar");
         assertEquals(URI.create("a"), link.getUri());
         assertNull(link.getRel());
+    }
+
+    @Test
+    public void testQuotedParamWithDelimiters() {
+        final FcrepoLink link = new FcrepoLink("<a>; foo=\"a,b;c=d\"");
+        assertEquals(URI.create("a"), link.getUri());
+        assertEquals("a,b;c=d", link.getParam("foo"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnquotedParamWithDelimiters() {
+        new FcrepoLink("<a>; foo=a;b");
     }
 
     @Test
@@ -151,36 +166,28 @@ public class FcrepoLinkTest {
     @Test
     public void testBuilder() {
         final FcrepoLink link = new FcrepoLink.Builder()
-                .uri("http://example.com/")
+                .uri(TEST_URI)
                 .rel("bar")
                 .type("foo")
                 .param("special", "val")
                 .build();
 
-        assertEquals(URI.create("http://example.com/"), link.getUri());
+        assertEquals(URI.create(TEST_URI), link.getUri());
         assertEquals("bar", link.getRel());
         assertEquals("foo", link.getType());
         assertEquals("val", link.getParam("special"));
     }
 
     @Test
-    public void testBuilderParamNeedingQuotes() {
-
-    }
-
-    @Test
     public void testToStringNoParams() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String header = String.format("<%s>", url);
+        final String header = String.format("<%s>", TEST_URI);
         final FcrepoLink link = new FcrepoLink(header);
         assertEquals(header, link.toString());
     }
 
     @Test
     public void testToStringWithParam() {
-        final String url = "http://localhost/rest/a/b/c";
-        final String rel = "describedby";
-        final String header = String.format("<%s>; rel=\"%s\"", url, rel);
+        final String header = String.format("<%s>; rel=\"%s\"", TEST_URI, DESCRIBEDBY_REL);
         final FcrepoLink link = new FcrepoLink(header);
         assertEquals(header, link.toString());
     }
@@ -188,16 +195,92 @@ public class FcrepoLinkTest {
     @Test
     public void testToStringMultipleParams() {
         final FcrepoLink link = new FcrepoLink.Builder()
-                .uri("http://example.com/")
+                .uri(TEST_URI)
                 .rel("bar")
                 .type("foo")
                 .param("special", "val")
                 .build();
 
         final String header = link.toString();
-        assertTrue("Stringified link did not contain URI", header.contains("<http://example.com/>"));
+        assertTrue("Stringified link did not contain URI", header.contains(TEST_URI));
         assertTrue("Stringified link did not contain rel", header.contains("; rel=\"bar\""));
         assertTrue("Stringified link did not contain type", header.contains("; type=\"foo\""));
         assertTrue("Stringified link did not contain param", header.contains("; special=\"val\""));
+    }
+
+    @Test
+    public void testValueOf() {
+        final String header = String.format("<%s>; rel=\"%s\"", TEST_URI, DESCRIBEDBY_REL);
+
+        final FcrepoLink link = FcrepoLink.valueOf(header);
+
+        assertEquals(TEST_URI, link.getUri().toString());
+        assertEquals(DESCRIBEDBY_REL, link.getRel());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testValueOfWithComma() {
+        FcrepoLink.valueOf(MULTI_LINK_HEADER);
+    }
+
+    @Test
+    public void testFromHeaderSingleLink() {
+        final String header = String.format("<%s>; rel=\"%s\"", TEST_URI, DESCRIBEDBY_REL);
+
+        final List<FcrepoLink> links = FcrepoLink.fromHeader(header);
+        assertEquals("Incorrect number of links returned", 1, links.size());
+
+        assertEquals(TEST_URI, links.get(0).getUri().toString());
+        assertEquals(DESCRIBEDBY_REL, links.get(0).getRel());
+    }
+
+    @Test
+    public void testFromHeaderMultipleLinks() {
+        final List<FcrepoLink> links = FcrepoLink.fromHeader(MULTI_LINK_HEADER);
+        assertEquals("Incorrect number of links returned", 2, links.size());
+
+        final FcrepoLink link1 = links.get(0);
+        assertEquals("http://a.example.org/", link1.getUri().toString());
+        assertEquals(MEMENTO_ORIGINAL_REL, link1.getRel());
+
+        final FcrepoLink link2 = links.get(1);
+        assertEquals("http://arxiv.example.net/timemap/http://a.example.org/", link2.getUri().toString());
+        assertEquals(MEMENTO_TIME_MAP_REL, link2.getRel());
+        assertEquals("application/link-format", link2.getType());
+        assertEquals("Tue, 15 Sep 2000 11:28:26 GMT", link2.getParam("from"));
+    }
+
+    @Test
+    public void testFromHeaderUriContainsComma() throws Exception {
+        final String header = String.format("<a,b>; rel=\"%s\"", DESCRIBEDBY_REL);
+
+        final List<FcrepoLink> links = FcrepoLink.fromHeader(header);
+        assertEquals("Incorrect number of links returned", 1, links.size());
+
+        assertEquals("a,b", links.get(0).getUri().toString());
+        assertEquals(DESCRIBEDBY_REL, links.get(0).getRel());
+    }
+
+    @Test
+    public void testFromHeaderParamContainsComma() throws Exception {
+        final String header = "<a>; param=\"value,with,commas\"";
+
+        final List<FcrepoLink> links = FcrepoLink.fromHeader(header);
+        assertEquals("Incorrect number of links returned", 1, links.size());
+
+        assertEquals("a", links.get(0).getUri().toString());
+        assertEquals("value,with,commas", links.get(0).getParam("param"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromHeaderUnterminatedUri() {
+        final String header = String.format("<a; rel=\"%s\"", DESCRIBEDBY_REL);
+        FcrepoLink.fromHeader(header);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromHeaderUnterminatedQuotes() {
+        final String header = String.format("<a>; rel=\"%s, <b>", DESCRIBEDBY_REL);
+        FcrepoLink.fromHeader(header);
     }
 }

--- a/src/test/java/org/fcrepo/client/FcrepoResponseTest.java
+++ b/src/test/java/org/fcrepo/client/FcrepoResponseTest.java
@@ -50,8 +50,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.core.Link;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.junit.Test;
@@ -278,7 +276,7 @@ public class FcrepoResponseTest {
     @Test
     public void testHasType() throws Exception {
         final Map<String, List<String>> headers = new HashMap<>();
-        final Link typeLink = Link.fromUri(MEMENTO_ORIGINAL_TYPE).rel(TYPE_REL).build();
+        final FcrepoLink typeLink = FcrepoLink.fromUri(MEMENTO_ORIGINAL_TYPE).rel(TYPE_REL).build();
         headers.put(LINK, Arrays.asList(typeLink.toString()));
 
         final URI uri = URI.create("http://localhost/foo");

--- a/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static java.net.URI.create;
+import static org.fcrepo.client.TestUtils.baseUrl;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.fcrepo.client.FedoraHeaderConstants.MEMENTO_DATETIME;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HistoricMementoBuilderTest {
+
+    private final String HISTORIC_DATETIME =
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
+
+    @Mock
+    private FcrepoClient client;
+
+    @Mock
+    private FcrepoResponse fcrepoResponse;
+
+    @Captor
+    private ArgumentCaptor<HttpRequestBase> requestCaptor;
+
+    private HistoricMementoBuilder testBuilder;
+
+    private URI uri;
+
+    @Before
+    public void setUp() throws Exception {
+        when(client.executeRequest(any(URI.class), any(HttpRequestBase.class)))
+                .thenReturn(fcrepoResponse);
+
+        uri = create(baseUrl);
+    }
+
+    @Test
+    public void testCreateWithInstantHeader() throws Exception {
+        final Instant datetime = LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC).toInstant();
+
+        testBuilder = new HistoricMementoBuilder(uri, client, datetime);
+        testBuilder.perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        assertEquals(HISTORIC_DATETIME, request.getFirstHeader(MEMENTO_DATETIME).getValue());
+    }
+
+    @Test
+    public void testCreateWithStringMementoDatetime() throws Exception {
+        testBuilder = new HistoricMementoBuilder(uri, client, HISTORIC_DATETIME);
+        testBuilder.perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        assertEquals(HISTORIC_DATETIME, request.getFirstHeader(MEMENTO_DATETIME).getValue());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testCreateWithNoDatetime() throws Exception {
+        testBuilder = new HistoricMementoBuilder(uri, client, (String) null);
+        testBuilder.perform();
+    }
+
+    @Test(expected = DateTimeParseException.class)
+    public void testCreateWithNonRFC1123() throws Exception {
+        final String mementoDatetime = Instant.now().toString();
+        testBuilder = new HistoricMementoBuilder(uri, client, mementoDatetime);
+        testBuilder.perform();
+    }
+}

--- a/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
@@ -50,7 +50,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class HistoricMementoBuilderTest {
 
     private final String HISTORIC_DATETIME =
-            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 0, 0).atZone(ZoneOffset.UTC));
 
     @Mock
     private FcrepoClient client;

--- a/src/test/java/org/fcrepo/client/PostBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PostBuilderTest.java
@@ -38,8 +38,6 @@ import static org.mockito.Mockito.when;
 import java.io.InputStream;
 import java.net.URI;
 
-import javax.ws.rs.core.Link;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -176,7 +174,7 @@ public class PostBuilderTest {
 
         final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
 
-        final Link extLink = Link.valueOf(request.getFirstHeader(LINK).getValue());
+        final FcrepoLink extLink = new FcrepoLink(request.getFirstHeader(LINK).getValue());
         assertEquals(EXTERNAL_CONTENT_REL, extLink.getRel());
         assertEquals(PROXY, extLink.getParams().get(EXTERNAL_CONTENT_HANDLING));
         assertEquals("plain/text", extLink.getType());
@@ -192,7 +190,7 @@ public class PostBuilderTest {
 
         final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
 
-        final Link extLink = Link.valueOf(request.getFirstHeader(LINK).getValue());
+        final FcrepoLink extLink = new FcrepoLink(request.getFirstHeader(LINK).getValue());
         assertEquals(EXTERNAL_CONTENT_REL, extLink.getRel());
         assertEquals(PROXY, extLink.getParams().get(EXTERNAL_CONTENT_HANDLING));
         assertNull(extLink.getType());

--- a/src/test/java/org/fcrepo/client/PutBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PutBuilderTest.java
@@ -40,8 +40,6 @@ import static org.mockito.Mockito.when;
 import java.io.InputStream;
 import java.net.URI;
 
-import javax.ws.rs.core.Link;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -122,7 +120,7 @@ public class PutBuilderTest {
 
         final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
 
-        final Link extLink = Link.valueOf(request.getFirstHeader(LINK).getValue());
+        final FcrepoLink extLink = new FcrepoLink(request.getFirstHeader(LINK).getValue());
         assertEquals(EXTERNAL_CONTENT_REL, extLink.getRel());
         assertEquals(PROXY, extLink.getParams().get(EXTERNAL_CONTENT_HANDLING));
         assertEquals("plain/text", extLink.getType());

--- a/src/test/java/org/fcrepo/client/integration/AbstractResourceIT.java
+++ b/src/test/java/org/fcrepo/client/integration/AbstractResourceIT.java
@@ -20,7 +20,10 @@ package org.fcrepo.client.integration;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoResponse;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -49,5 +52,11 @@ public abstract class AbstractResourceIT {
         connectionManager.setMaxTotal(Integer.MAX_VALUE);
         connectionManager.setDefaultMaxPerRoute(20);
         connectionManager.closeIdleConnections(3, TimeUnit.SECONDS);
+    }
+
+    protected Model getResponseModel(final FcrepoResponse resp) {
+        final Model model = ModelFactory.createDefaultModel();
+        model.read(resp.getBody(), null, "text/turtle");
+        return model;
     }
 }

--- a/src/test/java/org/fcrepo/client/integration/VersioningIT.java
+++ b/src/test/java/org/fcrepo/client/integration/VersioningIT.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client.integration;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.fcrepo.client.FedoraHeaderConstants.MEMENTO_DATETIME;
+import static org.fcrepo.client.FedoraTypes.MEMENTO_TYPE;
+import static org.fcrepo.client.LinkHeaderConstants.DESCRIBEDBY_REL;
+import static org.fcrepo.client.LinkHeaderConstants.MEMENTO_TIME_MAP_REL;
+import static org.fcrepo.client.TestUtils.rdfTtl;
+import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.kernel.api.RdfLexicon;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration("/spring-test/test-container.xml")
+public class VersioningIT extends AbstractResourceIT {
+
+    private static final Property DC_TITLE = createProperty("http://purl.org/dc/elements/1.1/title");
+
+    private final String HISTORIC_DATETIME =
+            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC));
+
+    protected URI url;
+
+    public VersioningIT() throws Exception {
+        super();
+
+        client = FcrepoClient.client()
+                .credentials("fedoraAdmin", "password")
+                .authScope("localhost")
+                .build();
+    }
+
+    @Test
+    public void testCreateMementoFromOriginal() throws Exception {
+        // Create original resource with custom property
+        final FcrepoResponse createOriginalResp = client.post(new URI(serverAddress))
+                .body(new ByteArrayInputStream(rdfTtl.getBytes()), "text/turtle")
+                .perform();
+
+        final URI timemapURI = createOriginalResp.getLinkHeaders(MEMENTO_TIME_MAP_REL).get(0);
+
+        final FcrepoResponse mementoResp = client.createMemento(timemapURI)
+                .perform();
+        assertEquals(CREATED.getStatusCode(), mementoResp.getStatusCode());
+
+        final URI mementoURI = mementoResp.getLocation();
+
+        final FcrepoResponse getResp = client.get(mementoURI).perform();
+        assertTrue("Retrieved object must be a memento", getResp.hasType(MEMENTO_TYPE));
+        final Model respModel = getResponseModel(getResp);
+        assertTrue(respModel.contains(null, DC_TITLE, "Test Object"));
+    }
+
+    // create memento from historic version, binary
+    @Test
+    public void testCreateHistoricBinaryMemento() throws Exception {
+        // Create original binary
+        final String mimetype = "text/plain";
+        final String bodyContent = "Hello world";
+        final FcrepoResponse createOriginalResp = client.post(new URI(serverAddress))
+                .body(new ByteArrayInputStream(bodyContent.getBytes()), mimetype)
+                .perform();
+
+        final URI originalURI = createOriginalResp.getLocation();
+        final URI timemapURI = createOriginalResp.getLinkHeaders(MEMENTO_TIME_MAP_REL).get(0);
+
+        // Create memento of the binary
+        final String mementoType = "text/old";
+        final String mementoContent = "Hello old world";
+        final FcrepoResponse binMementoResp = client.createMemento(timemapURI, HISTORIC_DATETIME)
+                .body(new ByteArrayInputStream(mementoContent.getBytes()), mementoType)
+                .perform();
+        assertEquals(CREATED.getStatusCode(), binMementoResp.getStatusCode());
+
+        // Determine location of description and its timemap
+        final URI descURI = binMementoResp.getLinkHeaders(DESCRIBEDBY_REL).get(0);
+        final URI descTimeMapURI = client.head(descURI).perform().getLinkHeaders(MEMENTO_TIME_MAP_REL).get(0);
+
+        // Create memento of the binary description
+        final String titleValue = "Ancient Binary";
+        // Modify the original model before creating memento
+        final Model originalModel = getResponseModel(client.get(descURI).perform());
+        final Resource resc = originalModel.getResource(originalURI.toString());
+        resc.addLiteral(DC_TITLE, titleValue);
+        // Set the updated mimetype for the memento
+        resc.removeAll(RdfLexicon.HAS_MIME_TYPE);
+        resc.addLiteral(RdfLexicon.HAS_MIME_TYPE, mementoType);
+
+        final FcrepoResponse descMementoResp = client.createMemento(descTimeMapURI, HISTORIC_DATETIME)
+                .body(modelToInputStream(originalModel), "text/turtle")
+                .perform();
+        assertEquals(CREATED.getStatusCode(), descMementoResp.getStatusCode());
+
+        // Verify the historic binary was created
+        final URI binaryMementoURI = binMementoResp.getLocation();
+        final FcrepoResponse getBinMementoResp = client.get(binaryMementoURI).perform();
+        final String getBinContent = IOUtils.toString(getBinMementoResp.getBody(), "UTF-8");
+
+        assertEquals(mementoContent, getBinContent);
+        assertEquals(mementoType, getBinMementoResp.getContentType());
+        assertTrue("Retrieved object must be a memento", getBinMementoResp.hasType(MEMENTO_TYPE));
+        assertEquals("Memento did not have expected datetime",
+                HISTORIC_DATETIME, getBinMementoResp.getHeaderValue(MEMENTO_DATETIME));
+
+        // TODO replace with datetime negotiation once implemented in client FCREPO-2945
+        final URI mementoDescURI = URI.create(binaryMementoURI.toString().replaceAll("fcr:versions",
+                "fcr:metadata/fcr:versions"));
+        // Verify that the description memento matches expectations
+        final FcrepoResponse getResp = client.get(mementoDescURI).perform();
+        assertEquals("Memento did not have expected datetime",
+                HISTORIC_DATETIME, getResp.getHeaderValue(MEMENTO_DATETIME));
+        final Model respModel = getResponseModel(getResp);
+        assertTrue("Memento must contain provided property",
+                respModel.contains(createResource(originalURI.toString()), DC_TITLE, titleValue));
+    }
+
+    // create memento from historic version, container
+    @Test
+    public void testCreateHistoricContainerMemento() throws Exception {
+        // Create original resource with custom property
+        final FcrepoResponse createOriginalResp = client.post(new URI(serverAddress))
+                .perform();
+
+        final URI originalURI = createOriginalResp.getLocation();
+        final URI timemapURI = createOriginalResp.getLinkHeaders(MEMENTO_TIME_MAP_REL).get(0);
+
+        // Add a property to the resource to use as the historic version
+        final String titleValue = "Very Historical";
+        final FcrepoResponse originalResp = client.get(originalURI).perform();
+        final Model originalModel = getResponseModel(originalResp);
+        originalModel.getResource(originalURI.toString())
+                .addLiteral(DC_TITLE, titleValue);
+
+        // Create historic memento with updated model
+        final FcrepoResponse mementoResp = client.createMemento(timemapURI, HISTORIC_DATETIME)
+                .body(modelToInputStream(originalModel), "text/turtle")
+                .perform();
+        assertEquals(CREATED.getStatusCode(), mementoResp.getStatusCode());
+
+        // Verify that the memento matches expectations
+        final URI mementoURI = mementoResp.getLocation();
+        final FcrepoResponse getResp = client.get(mementoURI).perform();
+        assertTrue("Retrieved object must be a memento", getResp.hasType(MEMENTO_TYPE));
+        assertEquals("Memento did not have expected datetime",
+                HISTORIC_DATETIME, getResp.getHeaderValue(MEMENTO_DATETIME));
+        final Model respModel = getResponseModel(getResp);
+        assertTrue("Memento must contain provided property",
+                respModel.contains(null, DC_TITLE, titleValue));
+    }
+
+    private InputStream modelToInputStream(final Model model) throws Exception {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        model.write(out, "text/turtle");
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2949

# What does this Pull Request do?
Adds support for creating historic and current mementos.

# What's new?
* Adds two new convenience request builders
  * a very basic one for mementos from the original version
  * one for creating historic mementos, which falls back into being a normal PostBuilder after providing providing the memento-datetime.
* Adds helper methods for identifying if a type is present in a response
* Removes FcrepoLink class, which is replaced by the rs-api implementation.
* Removes unused joda-time dependency
* Adds more constants related to headers, Link headers and memento types
* Adds integration tests for creating mementos
* Makes retrieval of headers from FcrepoResponse case insensitive (ran into case mismatches and it should not matter)

# How should this be tested?

`mvn clean install`

# Interested parties
@awoods @dbernstein 
