### PR TITLE
Fcrepo-2944 - Support Want-Digest

### DIFF
--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -64,6 +64,10 @@ public class FedoraHeaderConstants {
 
     public static final String LINK = "Link";
 
+    public static final String WANT_DIGEST = "Want-Digest";
+
+    public static final String CACHE_CONTROL = "Cache-Control";
+
     /**
      * Datetime for a memento, either provided when creating the memento or returned when retrieving one.
      */

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -18,10 +18,12 @@
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT;
+import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
+import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
 
 import java.net.URI;
 import java.util.List;
@@ -33,15 +35,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Builds a GET request to retrieve the content of a resource from the Fedora HTTP API
- * 
+ *
  * @author bbpennel
  */
-public class GetBuilder extends
-        RequestBuilder {
+public class GetBuilder extends RequestBuilder {
 
     /**
      * Construct a GetBuilder
-     * 
+     *
      * @param uri the target
      * @param client the client for this request
      */
@@ -56,7 +57,7 @@ public class GetBuilder extends
 
     /**
      * Add the accept header to this request to negotiate the response format.
-     * 
+     *
      * @param mediaType media type to set as the accept header. It should be a value from one of the allowed RDF
      *        source formats supported by Fedora.
      * @return this builder
@@ -70,7 +71,7 @@ public class GetBuilder extends
 
     /**
      * Set the byte range of content to retrieve
-     * 
+     *
      * @param rangeStart beginning byte index
      * @param rangeEnd ending byte index
      * @return this builder
@@ -93,7 +94,7 @@ public class GetBuilder extends
     /**
      * Set the prefer header for this request to minimal, to indicate that only triples directly related to a resource
      * should be returned.
-     * 
+     *
      * @return this builder
      */
     public GetBuilder preferMinimal() {
@@ -114,7 +115,7 @@ public class GetBuilder extends
     /**
      * Set the prefer header for this request to representation, to indicate that links to other resources and their
      * properties should also be included.
-     * 
+     *
      * @return this builder
      */
     public GetBuilder preferRepresentation() {
@@ -126,7 +127,7 @@ public class GetBuilder extends
      * Set the prefer header for this request to representation, to indicate that links to other resources and their
      * properties should also be included. The set of properties returned can be further specified by providing lists
      * of LDP defined preferences to omit or include.
-     * 
+     *
      * @param includeUris URIs of LDP defined preferences to include
      * @param omitUris URIs of LDP defined preferences to omit
      * @return this builder
@@ -159,7 +160,7 @@ public class GetBuilder extends
 
     /**
      * Provide an etag for the if-none-match header for this request
-     * 
+     *
      * @param etag etag to provide as the if-none-match header
      * @return this builder
      */
@@ -172,7 +173,7 @@ public class GetBuilder extends
 
     /**
      * Provide a if-last-modified header for this request
-     * 
+     *
      * @param lastModified date to provided as the if-modified-since header
      * @return this builder
      */
@@ -180,6 +181,30 @@ public class GetBuilder extends
         if (lastModified != null) {
             request.setHeader(IF_MODIFIED_SINCE, lastModified);
         }
+        return this;
+    }
+
+    /**
+     * Provide a Want-Digest header for this request
+     *
+     * @param value header value, following the syntax defined in:
+     *      https://tools.ietf.org/html/rfc3230#section-4.3.1
+     * @return this builder
+     */
+    public GetBuilder wantDigest(final String value) {
+        if (value != null) {
+            request.setHeader(WANT_DIGEST, value);
+        }
+        return this;
+    }
+
+    /**
+     * Provide a Cache-Control header with value "no-cache"
+     *
+     * @return this builder
+     */
+    public GetBuilder noCache() {
+        request.setHeader(CACHE_CONTROL, "no-cache");
         return this;
     }
 }

--- a/src/main/java/org/fcrepo/client/HeadBuilder.java
+++ b/src/main/java/org/fcrepo/client/HeadBuilder.java
@@ -17,6 +17,9 @@
  */
 package org.fcrepo.client;
 
+import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
+import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
+
 import java.net.URI;
 
 import org.apache.http.client.config.RequestConfig;
@@ -24,7 +27,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Builds a HEAD request to retrieve resource headers.
- * 
+ *
  * @author bbpennel
  */
 public class HeadBuilder extends
@@ -32,7 +35,7 @@ public class HeadBuilder extends
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri request will be issued to
      * @param client the client
      */
@@ -53,6 +56,30 @@ public class HeadBuilder extends
      */
     public HeadBuilder disableRedirects() {
         request.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
+        return this;
+    }
+
+    /**
+     * Provide a Want-Digest header for this request
+     *
+     * @param value header value, following the syntax defined in:
+     *      https://tools.ietf.org/html/rfc3230#section-4.3.1
+     * @return this builder
+     */
+    public HeadBuilder wantDigest(final String value) {
+        if (value != null) {
+            request.setHeader(WANT_DIGEST, value);
+        }
+        return this;
+    }
+
+    /**
+     * Provide a Cache-Control header with value "no-cache"
+     *
+     * @return this builder
+     */
+    public HeadBuilder noCache() {
+        request.setHeader(CACHE_CONTROL, "no-cache");
         return this;
     }
 }

--- a/src/main/java/org/fcrepo/client/HeaderHelpers.java
+++ b/src/main/java/org/fcrepo/client/HeaderHelpers.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static java.util.Optional.ofNullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Helpers for constructing headers.
+ *
+ * @author bbpennel
+ */
+public class HeaderHelpers {
+
+    /**
+     * Format a map of values to q values into a quality value formatted header, as per:
+     *  https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+     *
+     * For example, "md5;q=1.0, sha256,sha512;q=0.3"
+     *
+     * @param qualityMap mapping of values to their quality values.
+     * @return Formatted quality value header representation of the provided map.
+     */
+    public static String formatQualityValues(final Map<String, ? extends Object> qualityMap) {
+        // Group header values by common q values
+        final Map<Optional<Object>, List<Entry<String, ? extends Object>>> qualityToVal =
+                qualityMap.entrySet().stream()
+                .collect(Collectors.groupingBy(e -> ofNullable(e.getValue())));
+
+        // Join together all the groupings of q values to header values to produce final header
+        return qualityToVal.entrySet().stream()
+                .map(e -> {
+                    // Join together all the header values with the same q value
+                    final String joinedValues = e.getValue().stream()
+                            .map(Entry::getKey)
+                            .collect(Collectors.joining(","));
+                    // Add the q value if one was specified
+                    if (e.getKey().isPresent()) {
+                        return joinedValues + ";q=" + e.getKey().get();
+                    } else {
+                        return joinedValues;
+                    }
+                }) // join together the groupings
+                .collect(Collectors.joining(", "));
+    }
+
+    private HeaderHelpers() {
+    }
+}

--- a/src/test/java/org/fcrepo/client/GetBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/GetBuilderTest.java
@@ -19,10 +19,12 @@ package org.fcrepo.client;
 
 import static java.net.URI.create;
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT;
+import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
+import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
 import static org.fcrepo.client.TestUtils.baseUrl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -156,6 +158,22 @@ public class GetBuilderTest {
     public void testDisableRedirects() throws Exception {
         testBuilder.disableRedirects();
         assertFalse(testBuilder.request.getConfig().isRedirectsEnabled());
+    }
+
+    @Test
+    public void testWantDigest() throws Exception {
+        testBuilder.wantDigest("md5").perform();
+
+        final HttpRequestBase request = getRequest();
+        assertEquals("md5", request.getFirstHeader(WANT_DIGEST).getValue());
+    }
+
+    @Test
+    public void testNoCache() throws Exception {
+        testBuilder.noCache().perform();
+
+        final HttpRequestBase request = getRequest();
+        assertEquals("no-cache", request.getFirstHeader(CACHE_CONTROL).getValue());
     }
 
     private HttpRequestBase getRequest() throws FcrepoOperationFailedException {

--- a/src/test/java/org/fcrepo/client/HeaderHelpersTest.java
+++ b/src/test/java/org/fcrepo/client/HeaderHelpersTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author bbpennel
+ */
+public class HeaderHelpersTest {
+
+    @Test
+    public void testFormatQualityValues() {
+        final Map<String, Double> qualityMap = new HashMap<>();
+        qualityMap.put("md5", 1.0);
+
+        assertEquals("md5;q=1.0", HeaderHelpers.formatQualityValues(qualityMap));
+    }
+
+    @Test
+    public void testFormatQualityValuesNoQValue() {
+        final Map<String, Double> qualityMap = new HashMap<>();
+        qualityMap.put("md5", null);
+
+        assertEquals("md5", HeaderHelpers.formatQualityValues(qualityMap));
+    }
+
+    @Test
+    public void testFormatQualityValuesMultipleWithDifferentQ() {
+        final Map<String, String> qualityMap = new HashMap<>();
+        qualityMap.put("md5", "1.0");
+        qualityMap.put("sha-512", "0.4");
+
+        final String result = HeaderHelpers.formatQualityValues(qualityMap);
+        assertTrue(result.contains("md5;q=1.0"));
+        assertTrue(result.contains("sha-512;q=0.4"));
+    }
+
+    @Test
+    public void testFormatQualityValuesMultipleSameQ() {
+        final Map<String, Double> qualityMap = new HashMap<>();
+        qualityMap.put("md5", 1.0);
+        qualityMap.put("sha", 1.0);
+        qualityMap.put("sha-512", 0.4);
+
+        final String result = HeaderHelpers.formatQualityValues(qualityMap);
+        // can't guarantee order
+        assertTrue(result.contains("md5,sha;q=1.0") || result.contains("sha,md5;q=1.0"));
+        assertTrue(result.contains("sha-512;q=0.4"));
+    }
+
+    @Test
+    public void testFormatQualityValuesMultipleQ() {
+        final Map<String, Double> qualityMap = new HashMap<>();
+        qualityMap.put("md5", null);
+        qualityMap.put("sha", null);
+
+        final String result = HeaderHelpers.formatQualityValues(qualityMap);
+        // can't guarantee order
+        assertTrue(result.contains("md5,sha") || result.contains("sha,md5"));
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2944

# What does this Pull Request do?
Adds support for Want-Digest header in GET and HEAD requests, along with method to disable cache to ensure checksum gets generated.

# What's new?
* Adds methods for adding Want-Digest header
* Adds methods for setting Cache-Control: no-cache header
* Adds helper method for producing a properly formatted quality value header.

# How should this be tested?

`mvn clean install`

# Additional Notes:
Let me know if `formatQualityValues` seems like overkill. I was trying to more clearly support the requirements of the Want-Digest field (among others).

# Interested parties
@awoods @escowles 
