### PR TITLE
Fcrepo-2942 - Deprecate COPY and MOVE operations

### DIFF
--- a/src/main/java/org/fcrepo/client/CopyBuilder.java
+++ b/src/main/java/org/fcrepo/client/CopyBuilder.java
@@ -23,14 +23,16 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Builds a request to copy a resource (and its subtree) to a new location
- * 
+ *
  * @author bbpennel
+ * @deprecated the COPY method is not supported by the Fedora 1.0 specification
  */
+@Deprecated
 public class CopyBuilder extends MoveBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param sourceUrl uri of the resource
      * @param destinationUrl uri for the new path for the moved resource
      * @param client the client

--- a/src/main/java/org/fcrepo/client/FcrepoClient.java
+++ b/src/main/java/org/fcrepo/client/FcrepoClient.java
@@ -166,23 +166,27 @@ public class FcrepoClient {
     }
 
     /**
-     * Make a MOVE request to copy a resource (and its subtree) to a new location.
+     * Make a COPY request to copy a resource (and its subtree) to a new location.
      *
      * @param source url of the resource to copy
      * @param destination url of the location for the copy
      * @return a copy request builder object
+     * @deprecated the COPY method is not supported by the Fedora 1.0 specification
      */
+    @Deprecated
     public CopyBuilder copy(final URI source, final URI destination) {
         return new CopyBuilder(source, destination, this);
     }
 
     /**
-     * Make a COPY request to move a resource (and its subtree) to a new location.
+     * Make a MOVE request to move a resource (and its subtree) to a new location.
      *
      * @param source url of the resource to move
      * @param destination url of the new location for the resource
      * @return a move request builder object
+     * @deprecated the MOVE method is not supported by the Fedora 1.0 specification
      */
+    @Deprecated
     public MoveBuilder move(final URI source, final URI destination) {
         return new MoveBuilder(source, destination, this);
     }

--- a/src/main/java/org/fcrepo/client/MoveBuilder.java
+++ b/src/main/java/org/fcrepo/client/MoveBuilder.java
@@ -26,14 +26,16 @@ import org.apache.http.util.Args;
 
 /**
  * Builds a request to move a resource (and its subtree) to a new location
- * 
+ *
  * @author bbpennel
+ * @deprecated the MOVE method is not supported by the Fedora 1.0 specification
  */
+@Deprecated
 public class MoveBuilder extends RequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param sourceUrl uri of the resource
      * @param destinationUrl uri for the new path for the moved resource
      * @param client the client

--- a/src/test/java/org/fcrepo/client/MoveBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/MoveBuilderTest.java
@@ -39,6 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 /**
  * @author bbpennel
  */
+@SuppressWarnings("deprecation")
 @RunWith(MockitoJUnitRunner.class)
 public class MoveBuilderTest {
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2942

# What does this Pull Request do?
Deprecates COPY and MOVE classes and creation methods.

# How should this be tested?
`mvn clean install`

# Additional Notes:
There are no functional changes.

# Interested parties
@awoods 
