### PR TITLE
Fcrepo-2948 - Allow PATCH to specify any content ype

### DIFF
--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -25,7 +25,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 /**
  * Builds a PUT request for interacting with the Fedora HTTP API in order to modify the triples associated with a
  * resource with SPARQL-Update.
- * 
+ *
  * @author bbpennel
  */
 public class PatchBuilder extends BodyRequestBuilder {
@@ -34,7 +34,7 @@ public class PatchBuilder extends BodyRequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
@@ -48,10 +48,19 @@ public class PatchBuilder extends BodyRequestBuilder {
     }
 
     /**
-     * Patch defaults to a sparql update
+     * Add a body to this request from a stream, with application/sparql-update as its content type
+     *
+     * @param stream InputStream of the content to be sent to the server
+     * @return this builder
      */
+    @Override
     public PatchBuilder body(final InputStream stream) {
         return (PatchBuilder) super.body(stream, SPARQL_UPDATE);
+    }
+
+    @Override
+    public PatchBuilder body(final InputStream stream, final String contentType) {
+        return (PatchBuilder) super.body(stream, contentType);
     }
 
     @Override

--- a/src/test/java/org/fcrepo/client/PatchBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PatchBuilderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static java.net.URI.create;
+import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
+import static org.fcrepo.client.TestUtils.baseUrl;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PatchBuilderTest {
+
+    @Mock
+    private FcrepoClient client;
+
+    @Mock
+    private FcrepoResponse fcrepoResponse;
+
+    @Captor
+    private ArgumentCaptor<HttpRequestBase> requestCaptor;
+
+    private PatchBuilder testBuilder;
+
+    private URI uri;
+
+    @Before
+    public void setUp() throws Exception {
+        when(client.executeRequest(any(URI.class), any(HttpRequestBase.class)))
+                .thenReturn(fcrepoResponse);
+
+        uri = create(baseUrl);
+        testBuilder = new PatchBuilder(uri, client);
+    }
+
+    @Test
+    public void testWithBodyDefaultType() throws Exception {
+        final InputStream bodyStream = mock(InputStream.class);
+
+        testBuilder.body(bodyStream)
+                .perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        final HttpEntity bodyEntity = request.getEntity();
+        assertEquals(bodyStream, bodyEntity.getContent());
+
+        assertEquals("application/sparql-update", request.getFirstHeader(CONTENT_TYPE).getValue());
+    }
+
+    @Test
+    public void testWithBodyCustomType() throws Exception {
+        final InputStream bodyStream = mock(InputStream.class);
+
+        testBuilder.body(bodyStream, "text/plain")
+                .perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        final HttpEntity bodyEntity = request.getEntity();
+        assertEquals(bodyStream, bodyEntity.getContent());
+
+        assertEquals("text/plain", request.getFirstHeader(CONTENT_TYPE).getValue());
+    }
+}


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2948

# What does this Pull Request do?
Updates PatchBuilder.body method to allow users to provide a content type

# What's new?
* Adds override of body with content type

# How should this be tested?

`mvn clean install`

# Additional Notes:
This is to conform with MAY allowance in https://fedora.info/2018/11/22/spec/#http-patch for other content types.

# Interested parties
@awoods 
