### PR TITLE
Fcrepo-2945 - Accept-Datetime

### DIFF
--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -73,6 +73,8 @@ public class FedoraHeaderConstants {
      */
     public static final String MEMENTO_DATETIME = "Memento-Datetime";
 
+    public static final String ACCEPT_DATETIME = "Accept-Datetime";
+
     private FedoraHeaderConstants() {
     }
 }

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -18,19 +18,15 @@
 package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT;
-import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
-import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
-
 import java.net.URI;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 
 /**
@@ -38,7 +34,7 @@ import org.apache.http.client.methods.HttpRequestBase;
  *
  * @author bbpennel
  */
-public class GetBuilder extends RequestBuilder {
+public class GetBuilder extends RetrieveRequestBuilder {
 
     /**
      * Construct a GetBuilder
@@ -99,16 +95,6 @@ public class GetBuilder extends RequestBuilder {
      */
     public GetBuilder preferMinimal() {
         request.setHeader(PREFER, buildPrefer("minimal", null, null));
-        return this;
-    }
-
-    /**
-     * Disable following redirects.
-     *
-     * @return this builder
-     */
-    public GetBuilder disableRedirects() {
-        request.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
         return this;
     }
 
@@ -184,27 +170,18 @@ public class GetBuilder extends RequestBuilder {
         return this;
     }
 
-    /**
-     * Provide a Want-Digest header for this request
-     *
-     * @param value header value, following the syntax defined in:
-     *      https://tools.ietf.org/html/rfc3230#section-4.3.1
-     * @return this builder
-     */
-    public GetBuilder wantDigest(final String value) {
-        if (value != null) {
-            request.setHeader(WANT_DIGEST, value);
-        }
-        return this;
+    @Override
+    public GetBuilder disableRedirects() {
+        return (GetBuilder) super.disableRedirects();
     }
 
-    /**
-     * Provide a Cache-Control header with value "no-cache"
-     *
-     * @return this builder
-     */
+    @Override
+    public GetBuilder wantDigest(final String value) {
+        return (GetBuilder) super.wantDigest(value);
+    }
+
+    @Override
     public GetBuilder noCache() {
-        request.setHeader(CACHE_CONTROL, "no-cache");
-        return this;
+        return (GetBuilder) super.noCache();
     }
 }

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -23,6 +23,7 @@ import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -183,5 +184,15 @@ public class GetBuilder extends RetrieveRequestBuilder {
     @Override
     public GetBuilder noCache() {
         return (GetBuilder) super.noCache();
+    }
+
+    @Override
+    public GetBuilder acceptDatetime(final Instant acceptInstant) {
+        return (GetBuilder) super.acceptDatetime(acceptInstant);
+    }
+
+    @Override
+    public GetBuilder acceptDatetime(final String acceptDatetime) {
+        return (GetBuilder) super.acceptDatetime(acceptDatetime);
     }
 }

--- a/src/main/java/org/fcrepo/client/HeadBuilder.java
+++ b/src/main/java/org/fcrepo/client/HeadBuilder.java
@@ -18,6 +18,7 @@
 package org.fcrepo.client;
 
 import java.net.URI;
+import java.time.Instant;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
@@ -57,5 +58,15 @@ public class HeadBuilder extends RetrieveRequestBuilder {
     @Override
     public HeadBuilder noCache() {
         return (HeadBuilder) super.noCache();
+    }
+
+    @Override
+    public HeadBuilder acceptDatetime(final Instant acceptInstant) {
+        return (HeadBuilder) super.acceptDatetime(acceptInstant);
+    }
+
+    @Override
+    public HeadBuilder acceptDatetime(final String acceptDatetime) {
+        return (HeadBuilder) super.acceptDatetime(acceptDatetime);
     }
 }

--- a/src/main/java/org/fcrepo/client/HeadBuilder.java
+++ b/src/main/java/org/fcrepo/client/HeadBuilder.java
@@ -17,12 +17,8 @@
  */
 package org.fcrepo.client;
 
-import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
-import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
-
 import java.net.URI;
 
-import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 
 /**
@@ -30,8 +26,7 @@ import org.apache.http.client.methods.HttpRequestBase;
  *
  * @author bbpennel
  */
-public class HeadBuilder extends
-        RequestBuilder {
+public class HeadBuilder extends RetrieveRequestBuilder {
 
     /**
      * Instantiate builder
@@ -49,37 +44,18 @@ public class HeadBuilder extends
         return HttpMethods.HEAD.createRequest(targetUri);
     }
 
-    /**
-     * Disable following redirects.
-     *
-     * @return this builder
-     */
+    @Override
     public HeadBuilder disableRedirects() {
-        request.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
-        return this;
+        return (HeadBuilder) super.disableRedirects();
     }
 
-    /**
-     * Provide a Want-Digest header for this request
-     *
-     * @param value header value, following the syntax defined in:
-     *      https://tools.ietf.org/html/rfc3230#section-4.3.1
-     * @return this builder
-     */
+    @Override
     public HeadBuilder wantDigest(final String value) {
-        if (value != null) {
-            request.setHeader(WANT_DIGEST, value);
-        }
-        return this;
+        return (HeadBuilder) super.wantDigest(value);
     }
 
-    /**
-     * Provide a Cache-Control header with value "no-cache"
-     *
-     * @return this builder
-     */
+    @Override
     public HeadBuilder noCache() {
-        request.setHeader(CACHE_CONTROL, "no-cache");
-        return this;
+        return (HeadBuilder) super.noCache();
     }
 }

--- a/src/main/java/org/fcrepo/client/HeaderHelpers.java
+++ b/src/main/java/org/fcrepo/client/HeaderHelpers.java
@@ -17,8 +17,11 @@
  */
 package org.fcrepo.client;
 
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
 import static java.util.Optional.ofNullable;
 
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -31,6 +34,9 @@ import java.util.stream.Collectors;
  * @author bbpennel
  */
 public class HeaderHelpers {
+
+    // Formatter for converting instants to RFC1123 timestamps in UTC
+    public static DateTimeFormatter UTC_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
     /**
      * Format a map of values to q values into a quality value formatted header, as per:

--- a/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
+++ b/src/main/java/org/fcrepo/client/HistoricMementoBuilder.java
@@ -17,13 +17,11 @@
  */
 package org.fcrepo.client;
 
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
 import static org.fcrepo.client.FedoraHeaderConstants.MEMENTO_DATETIME;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 
 /**
  * Builds a POST request for creating a memento (LDPRm) with the state given in the request body
@@ -32,8 +30,6 @@ import java.time.format.DateTimeFormatter;
  * @author bbpennel
  */
 public class HistoricMementoBuilder extends PostBuilder {
-
-    private static DateTimeFormatter UTC_RFC_1123_FORMATTER = RFC_1123_DATE_TIME.withZone(ZoneId.of("UTC"));
 
     /**
      * Instantiate builder

--- a/src/main/java/org/fcrepo/client/RetrieveRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/RetrieveRequestBuilder.java
@@ -19,8 +19,11 @@ package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
+import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
+import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT_DATETIME;
 
 import java.net.URI;
+import java.time.Instant;
 
 import org.apache.http.client.config.RequestConfig;
 
@@ -65,6 +68,35 @@ public abstract class RetrieveRequestBuilder extends RequestBuilder {
      */
     public RetrieveRequestBuilder noCache() {
         request.setHeader(CACHE_CONTROL, "no-cache");
+        return this;
+    }
+
+    /**
+     * Provide an Accept-Datetime header in RFC1123 format from the given instant for memento datetime negotiation.
+     *
+     * @param acceptInstant the accept datetime represented as an Instant.
+     * @return this builder
+     */
+    public RetrieveRequestBuilder acceptDatetime(final Instant acceptInstant) {
+        if (acceptInstant != null) {
+            final String rfc1123Datetime = UTC_RFC_1123_FORMATTER.format(acceptInstant);
+            request.setHeader(ACCEPT_DATETIME, rfc1123Datetime);
+        }
+        return this;
+    }
+
+    /**
+     * Provide an Accept-Datetime from the given RFC1123 formatted string.
+     *
+     * @param acceptDatetime the accept datetime as a string, must be in RFC1123 format.
+     * @return this builder
+     */
+    public RetrieveRequestBuilder acceptDatetime(final String acceptDatetime) {
+        if (acceptDatetime != null) {
+            // Parse the datetime to ensure that it is in RFC1123 format
+            UTC_RFC_1123_FORMATTER.parse(acceptDatetime);
+            request.setHeader(ACCEPT_DATETIME, acceptDatetime);
+        }
         return this;
     }
 }

--- a/src/main/java/org/fcrepo/client/RetrieveRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/RetrieveRequestBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
+import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
+
+import java.net.URI;
+
+import org.apache.http.client.config.RequestConfig;
+
+/**
+ * Abstract builder for requests to retrieve information from the server
+ *
+ * @author bbpennel
+ */
+public abstract class RetrieveRequestBuilder extends RequestBuilder {
+
+    protected RetrieveRequestBuilder(final URI uri, final FcrepoClient client) {
+        super(uri, client);
+    }
+
+    /**
+     * Disable following redirects.
+     *
+     * @return this builder
+     */
+    public RetrieveRequestBuilder disableRedirects() {
+        request.setConfig(RequestConfig.custom().setRedirectsEnabled(false).build());
+        return this;
+    }
+
+    /**
+     * Provide a Want-Digest header for this request
+     *
+     * @param value header value, following the syntax defined in: https://tools.ietf.org/html/rfc3230#section-4.3.1
+     * @return this builder
+     */
+    public RetrieveRequestBuilder wantDigest(final String value) {
+        if (value != null) {
+            request.setHeader(WANT_DIGEST, value);
+        }
+        return this;
+    }
+
+    /**
+     * Provide a Cache-Control header with value "no-cache"
+     *
+     * @return this builder
+     */
+    public RetrieveRequestBuilder noCache() {
+        request.setHeader(CACHE_CONTROL, "no-cache");
+        return this;
+    }
+}

--- a/src/test/java/org/fcrepo/client/GetBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/GetBuilderTest.java
@@ -19,12 +19,14 @@ package org.fcrepo.client;
 
 import static java.net.URI.create;
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT;
+import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT_DATETIME;
 import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
 import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
+import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
 import static org.fcrepo.client.TestUtils.baseUrl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +36,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 
@@ -50,6 +54,9 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class GetBuilderTest {
+
+    private final String HISTORIC_DATETIME =
+            UTC_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 0, 0).atZone(ZoneOffset.UTC));
 
     @Mock
     private FcrepoClient client;
@@ -174,6 +181,14 @@ public class GetBuilderTest {
 
         final HttpRequestBase request = getRequest();
         assertEquals("no-cache", request.getFirstHeader(CACHE_CONTROL).getValue());
+    }
+
+    @Test
+    public void testAcceptDatetime() throws Exception {
+        testBuilder.acceptDatetime(HISTORIC_DATETIME).perform();
+
+        final HttpRequestBase request = getRequest();
+        assertEquals(HISTORIC_DATETIME, request.getFirstHeader(ACCEPT_DATETIME).getValue());
     }
 
     private HttpRequestBase getRequest() throws FcrepoOperationFailedException {

--- a/src/test/java/org/fcrepo/client/HeadBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HeadBuilderTest.java
@@ -18,9 +18,11 @@
 package org.fcrepo.client;
 
 import static java.net.URI.create;
+import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT_DATETIME;
 import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
 import static org.fcrepo.client.TestUtils.baseUrl;
+import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +31,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Before;
@@ -44,6 +49,9 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class HeadBuilderTest {
+
+    private final String HISTORIC_DATETIME =
+            UTC_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 0, 0).atZone(ZoneOffset.UTC));
 
     @Mock
     private FcrepoClient client;
@@ -96,5 +104,24 @@ public class HeadBuilderTest {
         verify(client).executeRequest(eq(uri), requestCaptor.capture());
         final HttpRequestBase request = requestCaptor.getValue();
         assertEquals("no-cache", request.getFirstHeader(CACHE_CONTROL).getValue());
+    }
+
+    @Test
+    public void testAcceptDatetime() throws Exception {
+        testBuilder.acceptDatetime(HISTORIC_DATETIME).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(HISTORIC_DATETIME, request.getFirstHeader(ACCEPT_DATETIME).getValue());
+    }
+
+    @Test
+    public void testAcceptDatetimeInstant() throws Exception {
+        final Instant datetime = LocalDateTime.of(2000, 1, 1, 00, 00).atZone(ZoneOffset.UTC).toInstant();
+        testBuilder.acceptDatetime(datetime).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(HISTORIC_DATETIME, request.getFirstHeader(ACCEPT_DATETIME).getValue());
     }
 }

--- a/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HistoricMementoBuilderTest.java
@@ -19,13 +19,13 @@ package org.fcrepo.client;
 
 import static java.net.URI.create;
 import static org.fcrepo.client.TestUtils.baseUrl;
-import static org.fcrepo.kernel.api.services.VersionService.MEMENTO_RFC_1123_FORMATTER;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.fcrepo.client.FedoraHeaderConstants.MEMENTO_DATETIME;
+import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
 
 import java.net.URI;
 import java.time.Instant;
@@ -50,7 +50,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class HistoricMementoBuilderTest {
 
     private final String HISTORIC_DATETIME =
-            MEMENTO_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 0, 0).atZone(ZoneOffset.UTC));
+            UTC_RFC_1123_FORMATTER.format(LocalDateTime.of(2000, 1, 1, 0, 0).atZone(ZoneOffset.UTC));
 
     @Mock
     private FcrepoClient client;


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2945

# What does this Pull Request do?
Allow clients to add Accept-datetime for datetime negotiation of mementos.

# What's new?
* HeadBuilder and GetBuilder have two signatures of `acceptDatetime`
* Split out common functions between Head and Get builders into parent class
* Consistently using the same date formatter, which has been moved to a shared test helper.

# How should this be tested?

`mvn clean install`

# Interested parties
@awoods 
