### PR TITLE
Fcrepo-2951 - Support state tokens

### DIFF
--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -20,6 +20,7 @@ package org.fcrepo.client;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MATCH;
+import static org.fcrepo.client.FedoraHeaderConstants.IF_STATE_TOKEN;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_UNMODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.LinkHeaderConstants.ACL_REL;
@@ -241,6 +242,19 @@ public abstract class BodyRequestBuilder extends
                     .rel(ACL_REL)
                     .build();
             request.addHeader(LINK, link.toString());
+        }
+        return this;
+    }
+
+    /**
+     * Provide a value for the if-state-token header for this request.
+     *
+     * @param token state token value
+     * @return this builder
+     */
+    protected BodyRequestBuilder ifStateToken(final String token) {
+        if (token != null) {
+            request.setHeader(IF_STATE_TOKEN, token);
         }
         return this;
     }

--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -60,6 +60,10 @@ public class FedoraHeaderConstants {
 
     public static final String ETAG = "ETag";
 
+    public static final String STATE_TOKEN = "X-State-Token";
+
+    public static final String IF_STATE_TOKEN = "X-If-State-Token";
+
     public static final String DESTINATION = "Destination";
 
     public static final String LINK = "Link";

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -73,6 +73,11 @@ public class PatchBuilder extends BodyRequestBuilder {
         return (PatchBuilder) super.ifUnmodifiedSince(modified);
     }
 
+    @Override
+    public PatchBuilder ifStateToken(final String token) {
+        return (PatchBuilder) super.ifStateToken(token);
+    }
+
     @Deprecated
     @Override
     public PatchBuilder digest(final String digest) {

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -82,6 +82,11 @@ public class PutBuilder extends BodyRequestBuilder {
         return (PutBuilder) super.ifUnmodifiedSince(modified);
     }
 
+    @Override
+    public PutBuilder ifStateToken(final String token) {
+        return (PutBuilder) super.ifStateToken(token);
+    }
+
     @Deprecated
     @Override
     public PutBuilder digest(final String digest) {

--- a/src/test/java/org/fcrepo/client/PatchBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PatchBuilderTest.java
@@ -19,6 +19,7 @@ package org.fcrepo.client;
 
 import static java.net.URI.create;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
+import static org.fcrepo.client.FedoraHeaderConstants.IF_STATE_TOKEN;
 import static org.fcrepo.client.TestUtils.baseUrl;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,5 +100,20 @@ public class PatchBuilderTest {
         assertEquals(bodyStream, bodyEntity.getContent());
 
         assertEquals("text/plain", request.getFirstHeader(CONTENT_TYPE).getValue());
+    }
+
+    @Test
+    public void testStateToken() throws Exception {
+        final InputStream bodyStream = mock(InputStream.class);
+        final String token = "state";
+
+        testBuilder.body(bodyStream)
+                .ifStateToken(token)
+                .perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        assertEquals(token, request.getFirstHeader(IF_STATE_TOKEN).getValue());
     }
 }

--- a/src/test/java/org/fcrepo/client/PutBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PutBuilderTest.java
@@ -24,6 +24,7 @@ import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MATCH;
+import static org.fcrepo.client.FedoraHeaderConstants.IF_STATE_TOKEN;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_UNMODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraTypes.LDP_DIRECT_CONTAINER;
@@ -208,5 +209,20 @@ public class PutBuilderTest {
         final FcrepoLink aclLink = new FcrepoLink(request.getFirstHeader(LINK).getValue());
         assertEquals(ACL_REL, aclLink.getRel());
         assertEquals("http://localhost/acl", aclLink.getUri().toString());
+    }
+
+    @Test
+    public void testStateToken() throws Exception {
+        final InputStream bodyStream = mock(InputStream.class);
+        final String token = "state";
+
+        testBuilder.body(bodyStream)
+                .ifStateToken(token)
+                .perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+
+        final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
+        assertEquals(token, request.getFirstHeader(IF_STATE_TOKEN).getValue());
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2951

# What does this Pull Request do?
Adds methods and constants to deal with state tokens

# What's new?
Put/PatchBuilder.stateToken methods
Constants for X-State-Token X-If-State-Token headers

# How should this be tested?

`mvn clean install`


# Additional Notes:
fcrepo5.0.0 does not support state tokens, so no integration test.

# Interested parties
@awoods 
