### PR TITLE
Fcrepo-2954 - Add headers

### DIFF
--- a/src/main/java/org/fcrepo/client/CopyBuilder.java
+++ b/src/main/java/org/fcrepo/client/CopyBuilder.java
@@ -37,12 +37,17 @@ public class CopyBuilder extends MoveBuilder {
      * @param destinationUrl uri for the new path for the moved resource
      * @param client the client
      */
-    protected CopyBuilder(final URI sourceUrl, final URI destinationUrl, final FcrepoClient client) {
+    public CopyBuilder(final URI sourceUrl, final URI destinationUrl, final FcrepoClient client) {
         super(sourceUrl, destinationUrl, client);
     }
 
     @Override
     protected HttpRequestBase createRequest() {
         return HttpMethods.COPY.createRequest(targetUri);
+    }
+
+    @Override
+    public CopyBuilder addHeader(final String name, final String value) {
+        return (CopyBuilder) super.addHeader(name, value);
     }
 }

--- a/src/main/java/org/fcrepo/client/DeleteBuilder.java
+++ b/src/main/java/org/fcrepo/client/DeleteBuilder.java
@@ -23,14 +23,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Builds a request to delete a resource
- * 
+ *
  * @author bbpennel
  */
 public class DeleteBuilder extends RequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri request will be issued to
      * @param client the client
      */
@@ -41,5 +41,10 @@ public class DeleteBuilder extends RequestBuilder {
     @Override
     protected HttpRequestBase createRequest() {
         return HttpMethods.DELETE.createRequest(targetUri);
+    }
+
+    @Override
+    public DeleteBuilder addHeader(final String name, final String value) {
+        return (DeleteBuilder) super.addHeader(name, value);
     }
 }

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -195,4 +195,14 @@ public class GetBuilder extends RetrieveRequestBuilder {
     public GetBuilder acceptDatetime(final String acceptDatetime) {
         return (GetBuilder) super.acceptDatetime(acceptDatetime);
     }
+
+    @Override
+    public GetBuilder addHeader(final String name, final String value) {
+        return (GetBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public GetBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (GetBuilder) super.addLinkHeader(linkHeader);
+    }
 }

--- a/src/main/java/org/fcrepo/client/HeadBuilder.java
+++ b/src/main/java/org/fcrepo/client/HeadBuilder.java
@@ -69,4 +69,14 @@ public class HeadBuilder extends RetrieveRequestBuilder {
     public HeadBuilder acceptDatetime(final String acceptDatetime) {
         return (HeadBuilder) super.acceptDatetime(acceptDatetime);
     }
+
+    @Override
+    public HeadBuilder addHeader(final String name, final String value) {
+        return (HeadBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public HeadBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (HeadBuilder) super.addLinkHeader(linkHeader);
+    }
 }

--- a/src/main/java/org/fcrepo/client/MoveBuilder.java
+++ b/src/main/java/org/fcrepo/client/MoveBuilder.java
@@ -40,7 +40,7 @@ public class MoveBuilder extends RequestBuilder {
      * @param destinationUrl uri for the new path for the moved resource
      * @param client the client
      */
-    protected MoveBuilder(final URI sourceUrl, final URI destinationUrl, final FcrepoClient client) {
+    public MoveBuilder(final URI sourceUrl, final URI destinationUrl, final FcrepoClient client) {
         super(sourceUrl, client);
         Args.notNull(destinationUrl, "Destination URL");
         // Add the required destination header to the request
@@ -50,5 +50,10 @@ public class MoveBuilder extends RequestBuilder {
     @Override
     protected HttpRequestBase createRequest() {
         return HttpMethods.MOVE.createRequest(targetUri);
+    }
+
+    @Override
+    public MoveBuilder addHeader(final String name, final String value) {
+        return (MoveBuilder) super.addHeader(name, value);
     }
 }

--- a/src/main/java/org/fcrepo/client/OptionsBuilder.java
+++ b/src/main/java/org/fcrepo/client/OptionsBuilder.java
@@ -23,15 +23,14 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Builds an OPTIONS request to output information about the supported HTTP methods, etc.
- * 
+ *
  * @author bbpennel
  */
-public class OptionsBuilder extends
-        RequestBuilder {
+public class OptionsBuilder extends RequestBuilder {
 
     /**
      * Instantiate builder
-     * 
+     *
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
@@ -42,5 +41,15 @@ public class OptionsBuilder extends
     @Override
     protected HttpRequestBase createRequest() {
         return HttpMethods.OPTIONS.createRequest(targetUri);
+    }
+
+    @Override
+    public OptionsBuilder addHeader(final String name, final String value) {
+        return (OptionsBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public OptionsBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (OptionsBuilder) super.addLinkHeader(linkHeader);
     }
 }

--- a/src/main/java/org/fcrepo/client/OriginalMementoBuilder.java
+++ b/src/main/java/org/fcrepo/client/OriginalMementoBuilder.java
@@ -34,7 +34,7 @@ public class OriginalMementoBuilder extends RequestBuilder {
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
-    protected OriginalMementoBuilder(final URI uri, final FcrepoClient client) {
+    public OriginalMementoBuilder(final URI uri, final FcrepoClient client) {
         super(uri, client);
     }
 
@@ -43,4 +43,13 @@ public class OriginalMementoBuilder extends RequestBuilder {
         return HttpMethods.POST.createRequest(targetUri);
     }
 
+    @Override
+    public OriginalMementoBuilder addHeader(final String name, final String value) {
+        return (OriginalMementoBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public OriginalMementoBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (OriginalMementoBuilder) super.addLinkHeader(linkHeader);
+    }
 }

--- a/src/main/java/org/fcrepo/client/PatchBuilder.java
+++ b/src/main/java/org/fcrepo/client/PatchBuilder.java
@@ -103,4 +103,14 @@ public class PatchBuilder extends BodyRequestBuilder {
     public PatchBuilder digestSha256(final String digest) {
         return (PatchBuilder) super.digestSha256(digest);
     }
+
+    @Override
+    public PatchBuilder addHeader(final String name, final String value) {
+        return (PatchBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public PatchBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (PatchBuilder) super.addLinkHeader(linkHeader);
+    }
 }

--- a/src/main/java/org/fcrepo/client/PostBuilder.java
+++ b/src/main/java/org/fcrepo/client/PostBuilder.java
@@ -103,8 +103,18 @@ public class PostBuilder extends BodyRequestBuilder {
     }
 
     @Override
-    protected PostBuilder linkAcl(final String aclUri) {
+    public PostBuilder linkAcl(final String aclUri) {
         return (PostBuilder) super.linkAcl(aclUri);
+    }
+
+    @Override
+    public PostBuilder addHeader(final String name, final String value) {
+        return (PostBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public PostBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (PostBuilder) super.addLinkHeader(linkHeader);
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -119,8 +119,18 @@ public class PutBuilder extends BodyRequestBuilder {
     }
 
     @Override
-    protected PutBuilder linkAcl(final String aclUri) {
+    public PutBuilder linkAcl(final String aclUri) {
         return (PutBuilder) super.linkAcl(aclUri);
+    }
+
+    @Override
+    public PutBuilder addHeader(final String name, final String value) {
+        return (PutBuilder) super.addHeader(name, value);
+    }
+
+    @Override
+    public PutBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        return (PutBuilder) super.addLinkHeader(linkHeader);
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/RequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/RequestBuilder.java
@@ -18,6 +18,7 @@
 package org.fcrepo.client;
 
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 
 import java.net.URI;
 
@@ -27,7 +28,7 @@ import org.slf4j.Logger;
 
 /**
  * Base RequestBuilder class for constructing requests to the Fedora API
- * 
+ *
  * @author bbpennel
  */
 public abstract class RequestBuilder {
@@ -45,7 +46,7 @@ public abstract class RequestBuilder {
 
     /**
      * Instantiate builder. Throws an IllegalArgumentException if either the uri or client are null.
-     * 
+     *
      * @param uri uri of the resource this request is being made to
      * @param client the client
      */
@@ -60,14 +61,14 @@ public abstract class RequestBuilder {
 
     /**
      * Creates the HTTP request object for this builder
-     * 
+     *
      * @return HTTP request object for this builder
      */
     protected abstract HttpRequestBase createRequest();
 
     /**
      * Performs the request constructed in this builder and returns the response
-     * 
+     *
      * @return the repository response
      * @throws FcrepoOperationFailedException when the underlying HTTP request results in an error
      */
@@ -78,4 +79,26 @@ public abstract class RequestBuilder {
         return client.executeRequest(targetUri, request);
     }
 
+    /**
+     * Add a header with the given name and value to the request.
+     *
+     * @param name name of the header
+     * @param value value of the header
+     * @return this builder
+     */
+    protected RequestBuilder addHeader(final String name, final String value) {
+        request.addHeader(name, value);
+        return this;
+    }
+
+    /**
+     * Add a link header to the request
+     *
+     * @param linkHeader link header value represented as a FcrepoLink
+     * @return this builder
+     */
+    protected RequestBuilder addLinkHeader(final FcrepoLink linkHeader) {
+        request.addHeader(LINK, linkHeader.toString());
+        return this;
+    }
 }

--- a/src/test/java/org/fcrepo/client/GetBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/GetBuilderTest.java
@@ -23,6 +23,7 @@ import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT_DATETIME;
 import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
 import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
@@ -189,6 +190,23 @@ public class GetBuilderTest {
 
         final HttpRequestBase request = getRequest();
         assertEquals(HISTORIC_DATETIME, request.getFirstHeader(ACCEPT_DATETIME).getValue());
+    }
+
+    @Test
+    public void testAddHeader() throws Exception {
+        testBuilder.addHeader("my-header", "head-val").perform();
+
+        final HttpRequestBase request = getRequest();
+        assertEquals("head-val", request.getFirstHeader("my-header").getValue());
+    }
+
+    @Test
+    public void testAddLinkHeader() throws Exception {
+        final FcrepoLink link = FcrepoLink.fromUri("http://example.com/link").type("foo").build();
+        testBuilder.addLinkHeader(link).perform();
+
+        final HttpRequestBase request = getRequest();
+        assertEquals(link.toString(), request.getFirstHeader(LINK).getValue());
     }
 
     private HttpRequestBase getRequest() throws FcrepoOperationFailedException {

--- a/src/test/java/org/fcrepo/client/HeadBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/HeadBuilderTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.client;
 import static java.net.URI.create;
 import static org.fcrepo.client.FedoraHeaderConstants.ACCEPT_DATETIME;
 import static org.fcrepo.client.FedoraHeaderConstants.CACHE_CONTROL;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.WANT_DIGEST;
 import static org.fcrepo.client.TestUtils.baseUrl;
 import static org.fcrepo.client.HeaderHelpers.UTC_RFC_1123_FORMATTER;
@@ -123,5 +124,24 @@ public class HeadBuilderTest {
         verify(client).executeRequest(eq(uri), requestCaptor.capture());
         final HttpRequestBase request = requestCaptor.getValue();
         assertEquals(HISTORIC_DATETIME, request.getFirstHeader(ACCEPT_DATETIME).getValue());
+    }
+
+    @Test
+    public void testAddHeader() throws Exception {
+        testBuilder.addHeader("my-header", "head-val").perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals("head-val", request.getFirstHeader("my-header").getValue());
+    }
+
+    @Test
+    public void testAddLinkHeader() throws Exception {
+        final FcrepoLink link = FcrepoLink.fromUri("http://example.com/link").type("foo").build();
+        testBuilder.addLinkHeader(link).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(link.toString(), request.getFirstHeader(LINK).getValue());
     }
 }

--- a/src/test/java/org/fcrepo/client/PatchBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PatchBuilderTest.java
@@ -20,6 +20,7 @@ package org.fcrepo.client;
 import static java.net.URI.create;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_STATE_TOKEN;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.TestUtils.baseUrl;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -115,5 +116,24 @@ public class PatchBuilderTest {
 
         final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
         assertEquals(token, request.getFirstHeader(IF_STATE_TOKEN).getValue());
+    }
+
+    @Test
+    public void testAddHeader() throws Exception {
+        testBuilder.addHeader("my-header", "head-val").perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals("head-val", request.getFirstHeader("my-header").getValue());
+    }
+
+    @Test
+    public void testAddLinkHeader() throws Exception {
+        final FcrepoLink link = FcrepoLink.fromUri("http://example.com/link").type("foo").build();
+        testBuilder.addLinkHeader(link).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(link.toString(), request.getFirstHeader(LINK).getValue());
     }
 }

--- a/src/test/java/org/fcrepo/client/PostBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PostBuilderTest.java
@@ -18,10 +18,10 @@
 package org.fcrepo.client;
 
 import static java.net.URI.create;
-import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.SLUG;
 import static org.fcrepo.client.FedoraTypes.LDP_DIRECT_CONTAINER;
 import static org.fcrepo.client.LinkHeaderConstants.ACL_REL;
@@ -225,5 +225,24 @@ public class PostBuilderTest {
         final FcrepoLink aclLink = new FcrepoLink(request.getFirstHeader(LINK).getValue());
         assertEquals(ACL_REL, aclLink.getRel());
         assertEquals("http://localhost/acl", aclLink.getUri().toString());
+    }
+
+    @Test
+    public void testAddHeader() throws Exception {
+        testBuilder.addHeader("my-header", "head-val").perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals("head-val", request.getFirstHeader("my-header").getValue());
+    }
+
+    @Test
+    public void testAddLinkHeader() throws Exception {
+        final FcrepoLink link = FcrepoLink.fromUri("http://example.com/link").type("foo").build();
+        testBuilder.addLinkHeader(link).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(link.toString(), request.getFirstHeader(LINK).getValue());
     }
 }

--- a/src/test/java/org/fcrepo/client/PutBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PutBuilderTest.java
@@ -18,7 +18,6 @@
 package org.fcrepo.client;
 
 import static java.net.URI.create;
-import static javax.ws.rs.core.HttpHeaders.LINK;
 import static org.fcrepo.client.ExternalContentHandling.PROXY;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
@@ -26,6 +25,7 @@ import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_STATE_TOKEN;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_UNMODIFIED_SINCE;
+import static org.fcrepo.client.FedoraHeaderConstants.LINK;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraTypes.LDP_DIRECT_CONTAINER;
 import static org.fcrepo.client.LinkHeaderConstants.EXTERNAL_CONTENT_HANDLING;
@@ -224,5 +224,24 @@ public class PutBuilderTest {
 
         final HttpEntityEnclosingRequestBase request = (HttpEntityEnclosingRequestBase) requestCaptor.getValue();
         assertEquals(token, request.getFirstHeader(IF_STATE_TOKEN).getValue());
+    }
+
+    @Test
+    public void testAddHeader() throws Exception {
+        testBuilder.addHeader("my-header", "head-val").perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals("head-val", request.getFirstHeader("my-header").getValue());
+    }
+
+    @Test
+    public void testAddLinkHeader() throws Exception {
+        final FcrepoLink link = FcrepoLink.fromUri("http://example.com/link").type("foo").build();
+        testBuilder.addLinkHeader(link).perform();
+
+        verify(client).executeRequest(eq(uri), requestCaptor.capture());
+        final HttpRequestBase request = requestCaptor.getValue();
+        assertEquals(link.toString(), request.getFirstHeader(LINK).getValue());
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2954

# What does this Pull Request do?
Adds methods for adding arbitrary headers.

# What's new?
Adds `.addHeader` and `.addLinkHeader` to all terminal request builders.

# How should this be tested?

`mvn clean install`

# Additional Notes:
I left out .addHeader(Header) on the assumption we didn't want to expose the underlying dependency on HttpClient. I also didn't add a setHeader method, since it seemed a little odd for a builder, but I'm not opposed to including one.

# Interested parties
@awoods 
