### PR TITLE
Fcrepo-2955 - Constants and cleanup

### DIFF
--- a/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
+++ b/src/main/java/org/fcrepo/client/BodyRequestBuilder.java
@@ -144,7 +144,7 @@ public abstract class BodyRequestBuilder extends
      *
      * @param digest checksum to provide as the digest for the request body
      * @param alg abbreviated algorithm identifier for the type of checksum being
-     *      added (for example, sha1, md5, etc)
+     *      added (for example, sha, md5, etc)
      * @return this builder
      */
     protected BodyRequestBuilder digest(final String digest, final String alg) {
@@ -165,7 +165,7 @@ public abstract class BodyRequestBuilder extends
      * @return this builder
      */
     protected BodyRequestBuilder digestSha1(final String digest) {
-        return digest(digest, "sha1");
+        return digest(digest, "sha");
     }
 
     /**

--- a/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/FedoraHeaderConstants.java
@@ -46,6 +46,8 @@ public class FedoraHeaderConstants {
 
     public static final String PREFER = "Prefer";
 
+    public static final String PREFERENCE_APPLIED = "Preference-Applied";
+
     public static final String RANGE = "Range";
 
     public static final String IF_NONE_MATCH = "If-None-Match";
@@ -78,6 +80,8 @@ public class FedoraHeaderConstants {
     public static final String MEMENTO_DATETIME = "Memento-Datetime";
 
     public static final String ACCEPT_DATETIME = "Accept-Datetime";
+
+    public static final String ACCEPT_EXTERNAL_CONTENT_HANDLING = "Accept-External-Content-Handling";
 
     private FedoraHeaderConstants() {
     }

--- a/src/main/java/org/fcrepo/client/GetBuilder.java
+++ b/src/main/java/org/fcrepo/client/GetBuilder.java
@@ -22,6 +22,8 @@ import static org.fcrepo.client.FedoraHeaderConstants.IF_MODIFIED_SINCE;
 import static org.fcrepo.client.FedoraHeaderConstants.IF_NONE_MATCH;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
 import static org.fcrepo.client.FedoraHeaderConstants.RANGE;
+import static org.fcrepo.client.PreferHeaderConstants.RETURN_REPRESENTATION;
+import static org.fcrepo.client.PreferHeaderConstants.RETURN_MINIMAL;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
@@ -95,7 +97,7 @@ public class GetBuilder extends RetrieveRequestBuilder {
      * @return this builder
      */
     public GetBuilder preferMinimal() {
-        request.setHeader(PREFER, buildPrefer("minimal", null, null));
+        request.setHeader(PREFER, RETURN_MINIMAL);
         return this;
     }
 
@@ -106,7 +108,7 @@ public class GetBuilder extends RetrieveRequestBuilder {
      * @return this builder
      */
     public GetBuilder preferRepresentation() {
-        request.setHeader(PREFER, buildPrefer("representation", null, null));
+        request.setHeader(PREFER, RETURN_REPRESENTATION);
         return this;
     }
 
@@ -120,13 +122,13 @@ public class GetBuilder extends RetrieveRequestBuilder {
      * @return this builder
      */
     public GetBuilder preferRepresentation(final List<URI> includeUris, final List<URI> omitUris) {
-        request.setHeader(PREFER, buildPrefer("representation", includeUris, omitUris));
+        request.setHeader(PREFER, buildPrefer(includeUris, omitUris));
         return this;
     }
 
-    private String buildPrefer(final String prefer, final List<URI> includeUris, final List<URI> omitUris) {
+    private String buildPrefer(final List<URI> includeUris, final List<URI> omitUris) {
         final StringJoiner preferJoin = new StringJoiner("; ");
-        preferJoin.add("return=" + prefer);
+        preferJoin.add(RETURN_REPRESENTATION);
 
         if (includeUris != null) {
             final String include = includeUris.stream().map(URI::toString).collect(Collectors.joining(" "));

--- a/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/LinkHeaderConstants.java
@@ -45,6 +45,9 @@ public class LinkHeaderConstants {
     // rel identifying the RDF resource describing this resource
     public static final String DESCRIBEDBY_REL = "describedby";
 
+    // rel identifying the NonRDFSource described by this resource
+    public static final String DESCRIBES_REL = "describes";
+
     // rel identifying the ACL for the resource
     public static final String ACL_REL = "acl";
 

--- a/src/main/java/org/fcrepo/client/PreferHeaderConstants.java
+++ b/src/main/java/org/fcrepo/client/PreferHeaderConstants.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.client;
+
+import java.net.URI;
+
+/**
+ * Constants for Prefer headers
+ *
+ * @author bbpennel
+ */
+public class PreferHeaderConstants {
+
+    // Embed "child" resources in the returned representation
+    public final static URI PREFER_CONTAINED_DESCRIPTIONS = URI.create(
+            "http://www.w3.org/ns/oa#PreferContainedDescriptions");
+
+    // Include/Exclude "ldp:contains" assertions to contained resources
+    public final static URI PREFER_CONTAINMENT = URI.create("http://www.w3.org/ns/ldp#PreferContainment");
+
+    // Include/Exclude assertions to member resources established by the Direct and Indirect containers
+    public final static URI PREFER_MEMBERSHIP = URI.create("http://www.w3.org/ns/ldp#PreferMembership");
+
+    // Include/Exclude triples that would be present when the container is empty
+    public final static URI PREFER_MINIMAL_CONTAINER = URI.create("http://www.w3.org/ns/ldp#PreferMinimalContainer");
+
+    // Include assertions from other Fedora resources to this node
+    public final static URI PREFER_INBOUND_REFERENCES = URI.create(
+            "http://fedora.info/definitions/fcrepo#PreferInboundReferences");
+
+    // Embed server managed properties in the representation
+    public final static URI PREFER_SERVER_MANAGED = URI.create(
+            "http://fedora.info/definitions/v4/repository#ServerManaged");
+
+    // Allows replacing the properties of a container without having to provide all of the server-managed triples
+    public final static String HANDLING_LENIENT = "handling=lenient; received=\"minimal\"";
+
+    // links to other resources and their properties should be included
+    public final static String RETURN_REPRESENTATION = "return=representation";
+
+    // only triples directly related to a resource should be returned
+    public final static String RETURN_MINIMAL = "return=minimal";
+
+    private PreferHeaderConstants() {
+    }
+}

--- a/src/main/java/org/fcrepo/client/PutBuilder.java
+++ b/src/main/java/org/fcrepo/client/PutBuilder.java
@@ -19,6 +19,7 @@ package org.fcrepo.client;
 
 import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_DISPOSITION;
 import static org.fcrepo.client.FedoraHeaderConstants.PREFER;
+import static org.fcrepo.client.PreferHeaderConstants.HANDLING_LENIENT;
 
 import java.io.File;
 import java.io.IOException;
@@ -157,7 +158,7 @@ public class PutBuilder extends BodyRequestBuilder {
      * @return this builder
      */
     public PutBuilder preferLenient() {
-        request.setHeader(PREFER, "handling=lenient; received=\"minimal\"");
+        request.setHeader(PREFER, HANDLING_LENIENT);
         return this;
     }
 }

--- a/src/test/java/org/fcrepo/client/PostBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PostBuilderTest.java
@@ -108,7 +108,7 @@ public class PostBuilderTest {
         assertEquals(bodyStream, bodyEntity.getContent());
 
         assertEquals("plain/text", request.getFirstHeader(CONTENT_TYPE).getValue());
-        assertEquals("sha1=checksum", request.getFirstHeader(DIGEST).getValue());
+        assertEquals("sha=checksum", request.getFirstHeader(DIGEST).getValue());
         assertEquals("slug_value", request.getFirstHeader(SLUG).getValue());
         assertEquals("attachment; filename=\"file.txt\"", request.getFirstHeader(CONTENT_DISPOSITION).getValue());
     }
@@ -142,7 +142,7 @@ public class PostBuilderTest {
         assertEquals(bodyStream, bodyEntity.getContent());
 
         assertEquals("plain/text", request.getFirstHeader(CONTENT_TYPE).getValue());
-        assertEquals("sha1=checksum, sha256=checksum256", request.getFirstHeader(DIGEST).getValue());
+        assertEquals("sha=checksum, sha256=checksum256", request.getFirstHeader(DIGEST).getValue());
     }
 
     @Test

--- a/src/test/java/org/fcrepo/client/PutBuilderTest.java
+++ b/src/test/java/org/fcrepo/client/PutBuilderTest.java
@@ -110,7 +110,7 @@ public class PutBuilderTest {
         assertEquals(bodyStream, bodyEntity.getContent());
 
         assertEquals("plain/text", request.getFirstHeader(CONTENT_TYPE).getValue());
-        assertEquals("sha1=checksum", request.getFirstHeader(DIGEST).getValue());
+        assertEquals("sha=checksum", request.getFirstHeader(DIGEST).getValue());
         assertEquals("attachment; filename=\"file.txt\"", request.getFirstHeader(CONTENT_DISPOSITION).getValue());
     }
 

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -173,7 +173,6 @@ public class FcrepoClientIT extends AbstractResourceIT {
         assertEquals(fileContent, getContent);
     }
 
-    @Ignore("Pending alignment with SHA1 rename")
     @Test
     public void testPostDigestMismatch() throws Exception {
         final String bodyContent = "Hello world";
@@ -187,7 +186,6 @@ public class FcrepoClientIT extends AbstractResourceIT {
         assertEquals("Invalid checksum was not rejected", CONFLICT.getStatusCode(), response.getStatusCode());
     }
 
-    @Ignore("Pending alignment with SHA1 rename")
     @Test
     public void testPostDigestMultipleChecksums() throws Exception {
         final String bodyContent = "Hello world";
@@ -202,7 +200,6 @@ public class FcrepoClientIT extends AbstractResourceIT {
         assertEquals("Checksums rejected", CREATED.getStatusCode(), response.getStatusCode());
     }
 
-    @Ignore("Pending alignment with SHA1 rename")
     @Test
     public void testPostDigestMultipleChecksumsOneMismatch() throws Exception {
         final String bodyContent = "Hello world";

--- a/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
+++ b/src/test/java/org/fcrepo/client/integration/FcrepoClientIT.java
@@ -33,8 +33,14 @@ import static org.fcrepo.client.FedoraHeaderConstants.CONTENT_TYPE;
 import static org.fcrepo.client.FedoraHeaderConstants.DIGEST;
 import static org.fcrepo.client.FedoraHeaderConstants.ETAG;
 import static org.fcrepo.client.FedoraHeaderConstants.LAST_MODIFIED;
+import static org.fcrepo.client.FedoraHeaderConstants.PREFERENCE_APPLIED;
 import static org.fcrepo.client.FedoraHeaderConstants.STATE_TOKEN;
 import static org.fcrepo.client.FedoraTypes.LDP_DIRECT_CONTAINER;
+import static org.fcrepo.client.PreferHeaderConstants.RETURN_MINIMAL;
+import static org.fcrepo.client.PreferHeaderConstants.RETURN_REPRESENTATION;
+import static org.fcrepo.client.PreferHeaderConstants.PREFER_CONTAINED_DESCRIPTIONS;
+import static org.fcrepo.client.PreferHeaderConstants.PREFER_MEMBERSHIP;
+import static org.fcrepo.client.PreferHeaderConstants.PREFER_CONTAINMENT;
 import static org.fcrepo.client.TestUtils.TEXT_TURTLE;
 import static org.fcrepo.client.TestUtils.sparqlUpdate;
 import static org.junit.Assert.assertEquals;
@@ -42,6 +48,8 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static java.util.Collections.singletonList;
+import static java.util.Arrays.asList;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -471,7 +479,23 @@ public class FcrepoClientIT extends AbstractResourceIT {
                 .perform();
 
         assertEquals(OK.getStatusCode(), response.getStatusCode());
-        assertEquals("return=minimal", response.getHeaderValue("Preference-Applied"));
+        assertEquals(RETURN_MINIMAL, response.getHeaderValue(PREFERENCE_APPLIED));
+    }
+
+    @Test
+    public void testGetPreferRepresentation() throws Exception {
+        create();
+
+        final FcrepoResponse response = client.get(url)
+                .preferRepresentation(asList(PREFER_MEMBERSHIP, PREFER_CONTAINED_DESCRIPTIONS),
+                        singletonList(PREFER_CONTAINMENT))
+                .perform();
+
+        assertEquals(OK.getStatusCode(), response.getStatusCode());
+        final String prefApplied = response.getHeaderValue(PREFERENCE_APPLIED);
+        assertTrue(prefApplied.contains(RETURN_REPRESENTATION));
+        assertTrue(prefApplied.contains("include"));
+        assertTrue(prefApplied.contains("omit"));
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2955

# What does this Pull Request do?
Adds constants for prefer headers and other fcrepo concepts. Fixes sha1 name for headers. Gets most ignored tests running.

# What's new?
* Adds PreferHeaderConstants class, makes use of for a few parts of the code base, adds integration test.
* Adds two missing header names
* Fixes the name of sha1 digest added via the client
* Updates authentication tests to work regardless of the default acl

# How should this be tested?

`mvn clean install`

# Additional Notes:
The auth tests probably should have been addressed for https://jira.duraspace.org/browse/FCREPO-2952 but it was closed with no changes, so just cleaning it up in this PR.

Many of these constants aren't used in the project, they are being offered to users of the client.

This is hopefully the end of the updates needed for fcrepo5 compatibility.

# Interested parties
@awoods @dbernstein 
